### PR TITLE
remove cause for warning: already initialized constant VERSION

### DIFF
--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-require File.expand_path('../lib/phony_rails/version', __FILE__)
+require 'phony_rails/version'
 
 Gem::Specification.new do |gem|
   gem.authors       = ["Joost Hietbrink"]


### PR DESCRIPTION
This warning occurs whenever loading a application that uses phony_rails.
