### PR TITLE
Address issue #11 - need to use a newer version of phony for additional countries

### DIFF
--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = PhonyRails::VERSION
 
-  gem.add_dependency "phony", "~> 1.7.7"
+  gem.add_dependency "phony", ">= 1.7.7"
   gem.add_dependency "countries", "~> 0.8.2"
   gem.add_dependency "activerecord", "~> 3.0"
 end


### PR DESCRIPTION
allowed dependencies on phony v 1.7.7 and above (rather than limiting to less than v 1.8)
