### PR TITLE
Do not pollute the global namespace with a Country class

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -1,5 +1,5 @@
 require 'phony'
-require 'countries'
+require 'iso3166'
 require 'phony_rails/string_extensions'
 require 'validators/phony_validator'
 require 'phony_rails/version'

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 describe PhonyRails do
 
+  it "should not pollute the global namespace with a Country class" do
+    should_not be_const_defined "Country"
+  end
+
   describe 'String extensions' do
     it "should phony_format a String" do
       "31101234123".phony_formatted(:format => :international, :spaces => '-').should eql('+31-10-1234123')
@@ -124,14 +128,14 @@ describe PhonyRails do
       home.normalized_phone1_method(:country_code => 'NL').should eql('31308612906')
     end
 
-    it "should use last passed options" do 
+    it "should use last passed options" do
       home = Home.new(:phone1_method => "(030) 8 61 29 06")
       home.normalized_phone1_method(:country_code => 'NL').should eql('31308612906')
       home.normalized_phone1_method(:country_code => 'DE').should eql('49308612906')
       home.normalized_phone1_method(:country_code => nil).should eql('49308612906')
     end
 
-    it "should use last object method" do 
+    it "should use last object method" do
       home = Home.new(:phone1_method => "(030) 8 61 29 06")
       home.country_code = 'NL'
       home.normalized_phone1_method.should eql('31308612906')
@@ -154,6 +158,6 @@ describe PhonyRails do
       home = Home.new(:phone_number => "+31-(0)10-1234123")
       home.valid?.should be_true
       home.phone_number_as_normalized.should eql('31101234123')
-    end    
+    end
   end
 end


### PR DESCRIPTION
Country is quite a commonly used model name, let's be a better citizen and not pollute the global namespace with such a class.
