### PR TITLE
Override the default loading of the "countries" gem so that the Country class isn't unqualified.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,8 @@
 source :rubygems
+
+# Preempt the default loading so that we don't get an unqualified Country class imported.
+gem 'countries', :require => 'iso3166'
+
 gemspec # Specify your gem's dependencies in phony_number.gemspec
 
 # For testing


### PR DESCRIPTION
Since phony_rails already uses the qualified class, there's no reason to blow away a Country class (which could easily be a common model name) in the app requiring this gem.

Incidentally, there was a test for this, but it only tested based on how PhonyRails loads the Countries gem when PhonyRails is required directly. The gemspec caused automatic loading of the default gem autoload for countries, which populated a Country class in the global namespace.
