### PR TITLE
Do not normalize an implausible phone

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -25,7 +25,7 @@ module PhonyRails
       # Add country_number if missing
       number = "#{country_number}#{number}" if not number =~ /^(00|\+)?#{country_number}/
     end
-    number = Phony.normalize(number)
+    number = Phony.normalize(number) if Phony.plausible?(number)
     return number.to_s
   rescue
     number # If all goes wrong .. we still return the original input.

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -34,6 +34,10 @@ describe PhonyRails do
       PhonyRails.normalize_number('+31-70-4157134', :country_code => 'NL').should eql('31704157134')
       PhonyRails.normalize_number('0323-2269497', :country_code => 'BE').should eql('323232269497')
     end
+
+    it "should not normalize an implausible number" do
+      PhonyRails.normalize_number('01').should eql('01')
+    end
   end
 
   describe 'defining ActiveRecord#phony_normalized_method' do


### PR DESCRIPTION
It can generate an unexpected string. Example:

``` ruby
Phony.normalize("01")
=> "1[#<Phony::NationalCode:0x007fc0745223a8 @national_splitter=#<Phony::NationalSplitters::Fixed:0x007fc074522448 @size=3, @zero=nil>, @local_splitter=#<Phony::LocalSplitters::Fixed:0x007fc07442d790 @format=[3, 14]>, @normalize=true>]"
```
