### PR TITLE
Make String#phony_formatted more tolerant

### DIFF
--- a/lib/phony_rails/string_extensions.rb
+++ b/lib/phony_rails/string_extensions.rb
@@ -5,9 +5,8 @@
     #   "31612341234".phony_formatted # => '06 12341234'
     #   "31612341234".phony_formatted(:spaces => '-') # => '06-12341234'
     def phony_formatted(options = {})
-      normalized = PhonyRails.normalize_number(self)
-      if normalized
-        Phony.formatted(normalized, options.reverse_merge(:format => :national))
+      if Phony.plausible?(self)
+        Phony.formatted(self.gsub(/[^0-9]/,''), options.reverse_merge(:format => :national))
       end
     end
 

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -21,6 +21,10 @@ describe PhonyRails do
     it "returns nil on blank string" do
       "".phony_formatted.should be_nil
     end
+
+    it "works on national phones" do
+      "31101234123".phony_formatted(:format => :national, :spaces => '').should eql("0101234123".phony_formatted(:format => :national, :spaces => ''))
+    end
   end
 
   describe 'PhonyRails#normalize_number' do


### PR DESCRIPTION
Made it tolerant against non-digit characters and idempotent so that

``` ruby
"+31101234123".phony_formatted.phony_formatted == "31101234123".phony_formatted
```
