### PR TITLE
Fix default_country_number appending repeatedly

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -26,7 +26,7 @@ module PhonyRails
       number = "#{country_number}#{number}" if not number =~ /^(00|\+)?#{country_number}/
     elsif default_country_number = country_number_for(options[:default_country_code])
       # Add default_country_number if missing
-      number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)/
+      number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)?#{default_country_number}/
     end
     number = Phony.normalize(number) if Phony.plausible?(number)
     return number.to_s


### PR DESCRIPTION
The regex for appending default country number doesn't correctly check if the actual country code is already there.

```
default_country_number = 1
number = '9545551212'
number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)/
=> "19545551212"

number = "19545551212"
number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)/
=> "119545551212"
```

etc.

Fixed:

```
default_country_number = 1
number = '9545551212'
number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)?#{default_country_number}/
=> "19545551212"
number = "#{default_country_number}#{number}" if not number =~ /^(00|\+)?#{default_country_number}/
=> "19545551212"
```

Sponsored-by: CentroNet Marketing
