### PR TITLE
PhonyRails.country_number_for should accept case agnostic country code

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -7,7 +7,7 @@ require 'phony_rails/version'
 module PhonyRails
 
   def self.country_number_for(country_code)
-    ISO3166::Country::Data[country_code].try(:[], 'country_code')
+    ISO3166::Country::Data[country_code.to_s.upcase].try(:[], 'country_code')
   end
 
   # This method requires a country_code attribute (eg. NL) and phone_number to be set.

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -86,6 +86,10 @@ describe PhonyRails do
         PhonyRails.normalize_number('4790909090', :country_code => 'SE').should eql('464790909090')
       end
 
+      it "should recognize lowercase country codes" do
+        PhonyRails.normalize_number('4790909090', :country_code => 'se').should eql('464790909090')
+      end
+
     end
 
     context 'number without a country code' do
@@ -106,6 +110,10 @@ describe PhonyRails do
 
       it "should prefer country_code over default_country_code" do
         PhonyRails.normalize_number('(030) 8 61 29 06', :country_code => 'DE', :default_country_code => 'NL').should eql('49308612906')
+      end
+
+      it "should recognize lowercase country codes" do
+        PhonyRails.normalize_number('010-1234123', :country_code => 'nl').should eql('31101234123')
       end
 
     end


### PR DESCRIPTION
I came across an issue with lowercase country code data (using Factual's Global Location data). Because I had lowercase country codes, `PhonyRails.country_number_for` was coming back `nil`, since the `ISO3166::Country::Data` hash uses capital letters as keys.

I'm assuming those who may use a lowercase country code e.g. "nl" intend "NL", and so I adjusted the `PhonyRails.country_number_for` method as such.

All tests are passing. Let me know if you're in agreement!

Cheers,
Aron
