### PR TITLE
Add Validates uniqueness to #validates_plausible_phone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,10 +9,11 @@ gemspec # Specify your gem's dependencies in phony_number.gemspec
 gem 'sqlite3'
 
 gem 'rake'
-gem 'rspec',          '~> 2.11.0'
+gem 'rspec',          '~> 2.12.0'
 gem 'guard',          '~> 1.2.0'
 gem 'guard-bundler',  '~> 1.0.0'
 gem 'guard-rspec',    '~> 1.2.0'
+gem 'debugger',       '~> 1.6.5'
 
 case RbConfig::CONFIG['host_os']
   when /darwin/i

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,9 +22,16 @@ GEM
       multi_json (~> 1.0)
     arel (3.0.2)
     builder (3.0.4)
+    columnize (0.3.6)
     countries (0.9.2)
       currencies (>= 0.4.0)
     currencies (0.4.2)
+    debugger (1.6.5)
+      columnize (>= 0.3.1)
+      debugger-linecache (~> 1.2.0)
+      debugger-ruby_core_source (~> 1.3.1)
+    debugger-linecache (1.2.0)
+    debugger-ruby_core_source (1.3.1)
     diff-lcs (1.1.3)
     ffi (1.9.0)
     growl (1.0.3)
@@ -56,14 +63,14 @@ GEM
       ffi (>= 0.5.0)
     rb-kqueue (0.2.0)
       ffi (>= 0.5.0)
-    rspec (2.11.0)
-      rspec-core (~> 2.11.0)
-      rspec-expectations (~> 2.11.0)
-      rspec-mocks (~> 2.11.0)
-    rspec-core (2.11.1)
-    rspec-expectations (2.11.3)
+    rspec (2.12.0)
+      rspec-core (~> 2.12.0)
+      rspec-expectations (~> 2.12.0)
+      rspec-mocks (~> 2.12.0)
+    rspec-core (2.12.2)
+    rspec-expectations (2.12.1)
       diff-lcs (~> 1.1.3)
-    rspec-mocks (2.11.3)
+    rspec-mocks (2.12.2)
     sqlite3 (1.3.8)
     thor (0.18.1)
     tzinfo (0.3.37)
@@ -74,6 +81,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (>= 3.0)
   countries
+  debugger (~> 1.6.5)
   growl
   guard (~> 1.2.0)
   guard-bundler (~> 1.0.0)
@@ -82,5 +90,5 @@ DEPENDENCIES
   phony_rails!
   rake
   rb-fsevent
-  rspec (~> 2.11.0)
+  rspec (~> 2.12.0)
   sqlite3

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -39,6 +39,7 @@ module ActiveModel
         # merged attributes are modified somewhere, so we are cloning them for each validator
         merged_attributes = _merge_attributes(attr_names)
 
+        validates_with ActiveRecord::Validations::UniquenessValidator, merged_attributes.clone if merged_attributes[:uniqueness]
         validates_with PresenceValidator, merged_attributes.clone if merged_attributes[:presence]
         validates_with FormatValidator, merged_attributes.clone if (merged_attributes[:with] or merged_attributes[:without])
         validates_with PhonyPlausibleValidator, merged_attributes.clone

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -54,6 +54,7 @@ module PhonyHelperMethods
 
     #tested
     validates_with ActiveModel::Validations::PresenceValidator, merged_attributes.clone if merged_attributes[:presence]
+    debugger if merged_attributes[:uniqueness]
     validates_with ActiveRecord::Validations::UniquenessValidator, merged_attributes.clone if merged_attributes[:uniqueness]
     validates_with ActiveModel::Validations::FormatValidator, merged_attributes.clone if (merged_attributes[:with] || merged_attributes[:without])
 

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -1,3 +1,4 @@
+require "debugger"
 # Uses the Phony.plausible method to validate an attribute.
 # Usage:
 #   validate :phone_number, :phony_plausible => true
@@ -31,20 +32,48 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
 
 end
 
+module PhonyHelperMethods
+
+  include ActiveRecord
+  include ActiveModel
+
+  def validates_plausible_phone(*attr_names)
+    # merged attributes are modified somewhere, so we are cloning them for each validator
+    merged_attributes = _merge_attributes(attr_names)
+
+    #validate with each ActiveRecord/Model validator.
+    #untested
+    validates_with ActiveModel::Validations::AbsenceValidator, merged_attributes.clone if merged_attributes[:absence]
+    validates_with ActiveModel::Validations::AcceptanceValidator, merged_attributes.clone if merged_attributes[:acceptance]
+    validates_with ActiveModel::Validations::ConfirmationValidator, merged_attributes.clone if merged_attributes[:confirmation]
+    validates_with ActiveModel::Validations::ExclusionValidator, merged_attributes.clone if merged_attributes[:exclusion]
+    validates_with ActiveModel::Validations::InclusionValidator, merged_attributes.clone if merged_attributes[:inclusion]
+    validates_with ActiveModel::Validations::LengthValidator, merged_attributes.clone if merged_attributes[:length]
+    validates_with ActiveModel::Validations::NumericalityValidator, merged_attributes.clone if merged_attributes[:numericality]
+    validates_with ActiveRecord::Validations::AssociatedValidator, merged_attributes.clone if merged_attributes[:associated]
+
+    #tested
+    validates_with ActiveModel::Validations::PresenceValidator, merged_attributes.clone if merged_attributes[:presence]
+    validates_with ActiveRecord::Validations::UniquenessValidator, merged_attributes.clone if merged_attributes[:uniqueness]
+    validates_with ActiveModel::Validations::FormatValidator, merged_attributes.clone if (merged_attributes[:with] || merged_attributes[:without])
+
+    validates_with PhonyPlausibleValidator, merged_attributes.clone
+  end
+
+end
+
 module ActiveModel
   module Validations
     module HelperMethods
+      include PhonyHelperMethods
+    end
+  end
+end
 
-      def validates_plausible_phone(*attr_names)
-        # merged attributes are modified somewhere, so we are cloning them for each validator
-        merged_attributes = _merge_attributes(attr_names)
-
-        validates_with ActiveRecord::Validations::UniquenessValidator, merged_attributes.clone if merged_attributes[:uniqueness]
-        validates_with PresenceValidator, merged_attributes.clone if merged_attributes[:presence]
-        validates_with FormatValidator, merged_attributes.clone if (merged_attributes[:with] or merged_attributes[:without])
-        validates_with PhonyPlausibleValidator, merged_attributes.clone
-      end
-
+module ActiveRecord
+  module Validations
+    module HelperMethods
+      include PhonyHelperMethods
     end
   end
 end

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 require 'spec_helper'
-
+require 'debugger'
 #-----------------------------------------------------------------------------------------------------------------------
 # Model
 #-----------------------------------------------------------------------------------------------------------------------
@@ -178,13 +178,15 @@ describe ActiveRecord::Validations::UniquenessValidator do
     context 'when a number\'s uniqueness is not required (:uniqueness = false)' do
 
       before(:each) do
-        @home = CommonHelpfulHome.new
+        @home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
+      end
+
+      after(:each) do
+        UniqueHelpfulHome.delete_all
       end
 
       it "should not invalidate existing numbers" do
-        @home.phone_number = VALID_NUMBER
-        copy_home = CommonHelpfulHome.new
-        copy_home.phone_number = VALID_NUMBER
+        copy_home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
         copy_home.should be_valid
       end
 
@@ -205,7 +207,11 @@ describe ActiveRecord::Validations::UniquenessValidator do
     context 'when a number is unique' do
 
       before(:each) do
-        @home = UniqueHelpfulHome.new
+        @home = UniqueHelpfulHome.new(phone_number: VALID_NUMBER)
+      end
+
+      after(:each) do
+        UniqueHelpfulHome.delete_all
       end
 
       it "should validate a unique number" do
@@ -214,11 +220,8 @@ describe ActiveRecord::Validations::UniquenessValidator do
       end
 
       it "should invalidate existing numbers" do
-        @home.phone_number = VALID_NUMBER
-        copy_home = UniqueHelpfulHome.new
-        copy_home.phone_number = VALID_NUMBER
-        copy_home.should_not be_valid
-        copy_home.errors.messages.should include(:phone_number => ["has already been taken"])
+        copy_home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
+        copy_home.should be_valid
       end
 
       it "should invalidate an invalid number" do

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -136,6 +136,7 @@ describe PhonyPlausibleValidator do
 
     it "should validate a valid number" do
       @home.phone_number = VALID_NUMBER
+      @home.save
       @home.should be_valid
     end
 
@@ -178,20 +179,23 @@ describe ActiveRecord::Validations::UniquenessValidator do
     context 'when a number\'s uniqueness is not required (:uniqueness = false)' do
 
       before(:each) do
-        @home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
+        @home = CommonHelpfulHome.new
       end
 
       after(:each) do
-        UniqueHelpfulHome.delete_all
+        CommonHelpfulHome.delete_all
       end
 
       it "should not invalidate existing numbers" do
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         copy_home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
         copy_home.should be_valid
       end
 
       it "should validate a valid number" do
-        @home.phone_number = VALID_NUMBER
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         @home.should be_valid
       end
 
@@ -207,7 +211,7 @@ describe ActiveRecord::Validations::UniquenessValidator do
     context 'when a number is unique' do
 
       before(:each) do
-        @home = UniqueHelpfulHome.new(phone_number: VALID_NUMBER)
+        @home = UniqueHelpfulHome.new
       end
 
       after(:each) do
@@ -215,13 +219,17 @@ describe ActiveRecord::Validations::UniquenessValidator do
       end
 
       it "should validate a unique number" do
-        @home.phone_number = VALID_NUMBER
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         @home.should be_valid
       end
 
       it "should invalidate existing numbers" do
-        copy_home = CommonHelpfulHome.create(phone_number: VALID_NUMBER)
-        copy_home.should be_valid
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
+        copy_home = UniqueHelpfulHome.create(phone_number: VALID_NUMBER)
+        # debugger
+        copy_home.should_not be_valid
       end
 
       it "should invalidate an invalid number" do
@@ -252,7 +260,8 @@ describe ActiveModel::Validations::HelperMethods do
       end
 
       it "should validate a valid number" do
-        @home.phone_number = VALID_NUMBER
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         @home.should be_valid
       end
 
@@ -278,6 +287,7 @@ describe ActiveModel::Validations::HelperMethods do
 
       it "should validate a valid number" do
         @home.phone_number = VALID_NUMBER
+        @home.save
         @home.should be_valid
       end
 
@@ -301,7 +311,8 @@ describe ActiveModel::Validations::HelperMethods do
       end
 
       it "should validate a valid number" do
-        @home.phone_number = VALID_NUMBER
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         @home.should be_valid
       end
 
@@ -350,7 +361,8 @@ describe ActiveModel::Validations::HelperMethods do
       end
 
       it "should validate a well formatted valid number" do
-        @home.phone_number = VALID_NUMBER
+        @home.save
+        @home.update_column(:phone_number, VALID_NUMBER)
         @home.should be_valid
       end
 
@@ -385,7 +397,8 @@ describe ActiveModel::Validations::HelperMethods do
       end
 
       it "should invalidate a valid number without a country code" do
-        @home.phone_number = VALID_NUMBER
+        @home = AustralianHelpfulHome.new(phone_number: VALID_NUMBER)
+        @home.save
         @home.should_not be_valid
         @home.errors.messages.should include(:phone_number => ["is an invalid number"])
       end
@@ -398,31 +411,44 @@ describe ActiveModel::Validations::HelperMethods do
         @home = BigHelpfulHome.new
       end
 
+      after(:each) do
+        BigHelpfulHome.delete_all
+      end
+
       it "should invalidate an empty number" do
         @home.should_not be_valid
       end
 
       it "should invalidate an invalid number" do
-        @home.phone_number = INVALID_NUMBER
-        @home.should_not be_valid
-        @home.errors.messages[:phone_number].should include "is an invalid number"
+        invalid_home = BigHelpfulHome.new(phone_number: INVALID_NUMBER)
+        invalid_home.should_not be_valid
+        invalid_home.errors.messages[:phone_number].should include "is an invalid number"
       end
 
       it "should invalidate a badly formatted number with the right country code" do
-        @home.phone_number = FRENCH_NUMBER_WITH_COUNTRY_CODE
-        @home.should_not be_valid
-        @home.errors.messages[:phone_number].should include "is invalid"
+        home = BigHelpfulHome.new(phone_number: FRENCH_NUMBER_WITH_COUNTRY_CODE)
+        home.should_not be_valid
+        home.errors.messages[:phone_number].should include "is invalid"
       end
 
       it "should invalidate a properly formatted number with the wrong country code" do
-        @home.phone_number = FORMATTED_AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE
-        @home.should_not be_valid
-        @home.errors.messages[:phone_number].should include "is an invalid number"
+        home = BigHelpfulHome.create(phone_number: FORMATTED_AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE)
+        home.should_not be_valid
+        home.errors.messages[:phone_number].should include "is an invalid number"
       end
 
       it "should validate a properly formatted number with the right country code" do
-        @home.phone_number = FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE
-        @home.should be_valid
+        home = BigHelpfulHome.create(phone_number: FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE)
+        home.should be_valid
+      end
+
+      it "should not create duplicates" do
+        home = BigHelpfulHome.create(phone_number: FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE)
+        home.save
+        home.update_column(:phone_number, FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE)
+        copy_home = BigHelpfulHome.create(phone_number: FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE)
+        # debugger
+        copy_home.should_not be_valid
       end
 
     end


### PR DESCRIPTION
Using rails 4.0 and ruby 2.1 I am using phony_rails to validate cellphone numbers. I want to ensure that phone numbers are unique, but in my spec it's causing a conflict with validates_uniqueness and it's not receiving the error.

```ruby
1) User should require case sensitive unique value for cellphone
     Failure/Error: it { should validate_uniqueness_of :cellphone }
       Expected errors to include "has already been taken" when cellphone is set to "a", got errors: ["email can't be blank (\"\")", "email can't be blank (\"\")", "email has already been taken (\"\")", "password can't be blank (nil)", "cellphone can't be blank (nil)"]
``` 

Spec using shoulda-matches

```ruby
  it { should validate_presence_of   :cellphone }
  it { should validate_uniqueness_of :cellphone }
```

User model

```ruby
  phony_normalized_method :cellphone
  phony_normalize :cellphone, default_country_code: 'US'

  validates_uniqueness_of :cellphone
  validates :cellphone, phony_plausible: true, presence: true
```

and migration:
```ruby
      t.string :cellphone,          null: false, default: ""
```

The spec for this pull request isn't passing, because the 
`Failure/Error: copy_home.should_not be_valid
 expected valid? to return false, got true`

I wanted to check to see if this was something you'd be interested in adding before I spent any more time figuring out why the spec isn't passing. Also, it would help to get another set of eyes on it.