### PR TITLE
Fix country code being incorrectly passed to phony

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,13 @@ so we can use:
 
 the i18n key is `:improbable_phone`
 
-You can also validate if a number has the correct country code:
+You can also validate if a number has the correct country number:
 
-    validates_plausible_phone :phone_number, :country_code => '61'
+    validates_plausible_phone :phone_number, :country_number => '61'
+
+or correct country code:
+
+    validates_plausible_phone :phone_number, :country_code => 'AU'
 
 ### Display / Views
 

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -8,7 +8,7 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
     return if value.blank?
 
     @record = record
-    @record.errors.add(attribute, error_message) if not Phony.plausible?(value, cc: country_code_or_country_number)
+    @record.errors.add(attribute, error_message) if not Phony.plausible?(value, cc: country_number)
   end
 
   private
@@ -17,12 +17,20 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
     options[:message] || :improbable_phone
   end
 
-  def country_code_or_country_number
-    options[:country_code] || record_country_number || record_country_code
+  def country_number
+    options[:country_number] || record_country_number || country_number_from_country_code
   end
 
   def record_country_number
     @record.country_number if @record.respond_to?(:country_number)
+  end
+
+  def country_number_from_country_code
+    PhonyRails.country_number_for(country_code)
+  end
+
+  def country_code
+    options[:country_code] || record_country_code
   end
 
   def record_country_code

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -38,6 +38,10 @@ ActiveRecord::Schema.define do
   create_table :australian_helpful_homes do |table|
     table.column :phone_number, :string
   end
+
+  create_table :polish_helpful_homes do |table|
+    table.column :phone_number, :string
+  end
 end
 
 #--------------------
@@ -79,13 +83,19 @@ end
 #--------------------
 class AustralianHelpfulHome < ActiveRecord::Base
   attr_accessor :phone_number
-  validates_plausible_phone :phone_number, :country_code => "61"
+  validates_plausible_phone :phone_number, :country_number => "61"
+end
+
+#--------------------
+class PolishHelpfulHome < ActiveRecord::Base
+  attr_accessor :phone_number
+  validates_plausible_phone :phone_number, :country_code => "PL"
 end
 
 #--------------------
 class BigHelpfulHome < ActiveRecord::Base
   attr_accessor :phone_number
-  validates_plausible_phone :phone_number, :presence => true, :with => /^\+\d+/, :country_code => "33"
+  validates_plausible_phone :phone_number, :presence => true, :with => /^\+\d+/, :country_number => "33"
 end
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -95,6 +105,7 @@ end
 I18n.locale = :en
 VALID_NUMBER = '1 555 555 5555'
 AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE = '61390133997'
+POLISH_NUMBER_WITH_COUNTRY_CODE = '48600600600'
 FORMATTED_AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE = '+61 390133997'
 FRENCH_NUMBER_WITH_COUNTRY_CODE = '33627899541'
 FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE = '+33 627899541'
@@ -280,7 +291,7 @@ describe ActiveModel::Validations::HelperMethods do
     end
 
     #--------------------
-    context 'when a number must include a specific country code' do
+    context 'when a number must include a specific country number' do
 
       before(:each) do
         @home = AustralianHelpfulHome.new
@@ -292,6 +303,36 @@ describe ActiveModel::Validations::HelperMethods do
 
       it "should validate a valid number with the right country code" do
         @home.phone_number = AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE
+        @home.should be_valid
+      end
+
+      it "should invalidate a valid number with the wrong country code" do
+        @home.phone_number = FRENCH_NUMBER_WITH_COUNTRY_CODE
+        @home.should_not be_valid
+        @home.errors.messages.should include(:phone_number => ["is an invalid number"])
+      end
+
+      it "should invalidate a valid number without a country code" do
+        @home.phone_number = VALID_NUMBER
+        @home.should_not be_valid
+        @home.errors.messages.should include(:phone_number => ["is an invalid number"])
+      end
+
+    end
+
+    #--------------------
+    context 'when a number must include a specific country code' do
+
+      before(:each) do
+        @home = PolishHelpfulHome.new
+      end
+
+      it "should validate an empty number" do
+        @home.should be_valid
+      end
+
+      it "should validate a valid number with the right country code" do
+        @home.phone_number = POLISH_NUMBER_WITH_COUNTRY_CODE
         @home.should be_valid
       end
 


### PR DESCRIPTION
In `PhonyPlausibleValidator`.

You cannot pass country code (like 'NL') to `Phony.plausible?` as it
allows only country numbers (like '31'):

```
Phony.plausible?('+1 555 1234 123', cc: 'US')
=> false

Phony.plausible?('+1 555 1234 123', cc: '1')
=> true
```

Also make a strong distinction between country codes and country numbers
and don't use one when you mean the other.

Fixes #48.
