### PR TITLE
Fixes #55 - Validation fails if record country code does not match code ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.rvmrc
 /.idea/
+.ruby-gemset
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ or correct country code:
 
     validates_plausible_phone :phone_number, :country_code => 'AU'
 
+#### Allowing records country codes to not match phone number country codes
+
+You may have a record specifying one county (via a `county_code` attribute) but using a phone number from another country.  For example, your record may be from Japan but have a phone number from the Philippines. By default, `phony_rails` will consider your record's `county_code` as part of the validation.  If that country doesn't match the country code in the phone number, validation will fail.  
+
+If you want to allow records from one country to have phone numbers from a different one, there are a couple of options you can use: `ignore_record_country_number` and `ignore_record_country_code`.  Use them like so:
+
+    validates :phone_number, :phony_plausible => { :ignore_record_country_code => true, :ignore_record_country_number => true}
+
+Obviously, you don't have to use both, and you may not need or want to set either.  They only matter if your model `responds_to?` `:country_code` or `:country_number`.
+
 ### Display / Views
 
 In your views use:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ or correct country code:
 
 #### Allowing records country codes to not match phone number country codes
 
-You may have a record specifying one county (via a `county_code` attribute) but using a phone number from another country.  For example, your record may be from Japan but have a phone number from the Philippines. By default, `phony_rails` will consider your record's `county_code` as part of the validation.  If that country doesn't match the country code in the phone number, validation will fail.  
+You may have a record specifying one country (via a `country_code` attribute) but using a phone number from another country.  For example, your record may be from Japan but have a phone number from the Philippines. By default, `phony_rails` will consider your record's `country_code` as part of the validation.  If that country doesn't match the country code in the phone number, validation will fail.  
 
 If you want to allow records from one country to have phone numbers from a different one, there are a couple of options you can use: `ignore_record_country_number` and `ignore_record_country_code`.  Use them like so:
 

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -22,7 +22,7 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   end
 
   def record_country_number
-    @record.country_number if @record.respond_to?(:country_number)
+    @record.country_number if @record.respond_to?(:country_number) && !options[:ignore_record_country_number]
   end
 
   def country_number_from_country_code
@@ -34,7 +34,7 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   end
 
   def record_country_code
-    @record.country_code if @record.respond_to?(:country_code)
+    @record.country_code if @record.respond_to?(:country_code) && !options[:ignore_record_country_code]
   end
 
 end

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -42,6 +42,10 @@ ActiveRecord::Schema.define do
   create_table :polish_helpful_homes do |table|
     table.column :phone_number, :string
   end
+
+  create_table :mismatched_helpful_homes do |table|
+    table.column :phone_number, :string
+  end
 end
 
 #--------------------
@@ -98,6 +102,11 @@ class BigHelpfulHome < ActiveRecord::Base
   validates_plausible_phone :phone_number, :presence => true, :with => /^\+\d+/, :country_number => "33"
 end
 
+#--------------------
+class MismatchedHelpfulHome < ActiveRecord::Base
+  attr_accessor :phone_number, :country_code
+  validates :phone_number, :phony_plausible => {:ignore_record_country_code => true}
+end
 #-----------------------------------------------------------------------------------------------------------------------
 # Tests
 #-----------------------------------------------------------------------------------------------------------------------
@@ -110,6 +119,7 @@ FORMATTED_AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE = '+61 390133997'
 FRENCH_NUMBER_WITH_COUNTRY_CODE = '33627899541'
 FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE = '+33 627899541'
 INVALID_NUMBER = '123456789 123456789 123456789 123456789'
+JAPAN_COUNTRY = 'jp'
 
 #-----------------------------------------------------------------------------------------------------------------------
 describe PhonyPlausibleValidator do
@@ -383,6 +393,19 @@ describe ActiveModel::Validations::HelperMethods do
         @home.should be_valid
       end
 
+    end
+
+    #--------------------
+    context 'when a phone number does not match the records country' do
+      before(:each) do
+        @home = MismatchedHelpfulHome.new
+        @home.country_code = JAPAN_COUNTRY
+        @home.phone_number = FRENCH_NUMBER_WITH_COUNTRY_CODE
+      end
+
+      it "should allow this number" do
+        @home.should be_valid
+      end
     end
 
   end


### PR DESCRIPTION
...in phone number

Allow for ignoring the record's country code and country number even if
the record responds to them.

I took your approach and used 2 flags.  I reversed the logic on them though, so that existing users wouldn't see a difference.  This is something to opt out of rather than make everyone opt into it.