### PR TITLE
Raise runtime errors not argument errors when :as attr undefined

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -67,8 +67,8 @@ module PhonyRails
         options.assert_valid_keys :country_code, :default_country_code, :as
         if options[:as].present?
           raise ArgumentError, ':as option can not be used on phony_normalize with multiple attribute names! (PhonyRails)' if attributes.size > 1
-          raise ArgumentError, "'#{options[:as]}' is not an attribute on #{self.name}. You might want to use 'phony_normalized_method :#{attributes.first}' (PhonyRails)" if not self.attribute_method?(options[:as])
         end
+
         # Add before validation that saves a normalized version of the phone number
         self.before_validation do
           set_phony_normalized_numbers(attributes, options)

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -187,16 +187,16 @@ describe PhonyRails do
         }.should raise_error(ArgumentError)
       end
 
-      it "should not accept :as option with unexisting attribute name" do
+      it "should accept :as option with non existing attribute name" do
         lambda {
-          model_klass.phony_normalize(:non_existing_attribute, :as => 'non_existing_attribute')
-        }.should raise_error(ArgumentError)
+          dummy_klass.phony_normalize(:non_existing_attribute, :as => 'non_existing_attribute')
+        }.should_not raise_error
       end
 
-      it "should not accept :as option with single non existing attribute name" do
+      it "should accept :as option with single non existing attribute name" do
         lambda {
-          model_klass.phony_normalize(:phone_number, :as => 'something_else')
-        }.should raise_error(ArgumentError)
+          dummy_klass.phony_normalize(:phone_number, :as => 'something_else')
+        }.should_not raise_error
       end
 
       it "should accept :as option with single existing attribute name" do
@@ -289,6 +289,14 @@ describe PhonyRails do
 
       it "should raise a RuntimeError at validation if the attribute doesn't exist" do
         dummy_klass.phony_normalize :non_existing_attribute
+        dummy = dummy_klass.new
+        lambda {
+          dummy.valid?
+        }.should raise_error(RuntimeError)
+      end
+
+      it "should raise a RuntimeError at validation if the :as option attribute doesn't exist" do
+        dummy_klass.phony_normalize :phone_number, :as => :non_existing_attribute
         dummy = dummy_klass.new
         lambda {
           dummy.valid?


### PR DESCRIPTION
Fixes #60 (For varying definitions of fixes)

Raise a runtime error at validation instead of argument error when the app initialises.

This allows migrations to be run for new attributes without having to use `attr_accessor` or comment out `phony_normalize` in the model.
