### PR TITLE
Ability to validate against the normalized input

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phony_rails (0.7.0)
+    phony_rails (0.7.2)
       activesupport (>= 3.0)
       countries (>= 0.8.2)
       phony (~> 2.4.3)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ or correct country code:
 
     validates_plausible_phone :phone_number, :country_code => 'AU'
 
+You can validate against the normalized input as opposed to the raw input:
+
+    phony_normalize :phone_number, as: :phone_number_normalized, :default_country_code => 'US'
+    validates_plausible_phone :phone_number, :normalized_country_code => 'US'
+
 ### Display / Views
 
 In your views use:

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -8,6 +8,8 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
     return if value.blank?
 
     @record = record
+
+    value = PhonyRails.normalize_number value, default_country_code: normalized_country_code if normalized_country_code
     @record.errors.add(attribute, error_message) if not Phony.plausible?(value, cc: country_number)
   end
 
@@ -35,6 +37,10 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
 
   def record_country_code
     @record.country_code if @record.respond_to?(:country_code)
+  end
+
+  def normalized_country_code
+    options[:normalized_country_code]
   end
 
 end


### PR DESCRIPTION
Useful in the scenario when you want to allow

```
#10 digits are extremely common in the US
555 555 5555
```

even though it would fail Phony.plausible?().

After normalizing for “US”, this would pass.
i.e. Phony.plausible?(PhonyRails.normalize_number)

Usage looks like:

``` ruby
validates_plausible_phone :phone_number, normalized_country_code: 'US'
```
