### PR TITLE
Remove depreciation warnings while running tests.

### DIFF
--- a/Guardfile
+++ b/Guardfile
@@ -5,7 +5,7 @@ guard 'bundler' do
   watch(/^.+\.gemspec/)
 end
 
-guard 'rspec', :version => 2 do
+guard 'rspec', cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
   watch('spec/spec_helper.rb')  { "spec" }

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -203,7 +203,7 @@ describe PhonyRails do
       it "should accept :as option with single existing attribute name" do
         lambda {
           model_klass.phony_normalize(:phone_number, :as => 'phone_number_as_normalized')
-        }.should_not raise_error(ArgumentError)
+        }.should_not raise_error
       end
 
       it "should accept a non existing attribute name" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,8 @@ end
 class MongoidDummy < MongoidModel
 end
 
+I18n.config.enforce_available_locales = true
+
 RSpec.configure do |config|
   # some (optional) config here
 end


### PR DESCRIPTION
Removes I18n, rspec and guard depreciation warnings. Add `cmd` option to rspec guard.
