### PR TITLE
Fix incorrect Japanese translation

### DIFF
--- a/lib/phony_rails/locales/ja.yml
+++ b/lib/phony_rails/locales/ja.yml
@@ -1,4 +1,4 @@
 ja:
   errors:
     messages:
-      improbable_phone: "は正し電話番号ではありません"
+      improbable_phone: "は正しい電話番号ではありません"

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -177,7 +177,7 @@ describe PhonyPlausibleValidator do
       I18n.with_locale(:ja) do
         @home.phone_number = INVALID_NUMBER
         @home.valid?
-        @home.errors.messages.should include(:phone_number => ["は正し電話番号ではありません"])
+        @home.errors.messages.should include(:phone_number => ["は正しい電話番号ではありません"])
       end
     end
 


### PR DESCRIPTION
"正し" is not a Japanese is generally used. The "正しい" it would be appropriate.

ref: http://ejje.weblio.jp/content/%E6%AD%A3%E3%81%97%E3%81%84