### PR TITLE
allow all valid options

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -80,7 +80,7 @@ module PhonyRails
       # you've geocoded before calling this method!
       def phony_normalize(*attributes)
         options = attributes.last.is_a?(Hash) ? attributes.pop : {}
-        options.assert_valid_keys :country_code, :default_country_code, :as
+        options.assert_valid_keys :country_number, :default_country_number, :country_code, :default_country_code, :add_plus, :as
         if options[:as].present?
           raise ArgumentError, ':as option can not be used on phony_normalize with multiple attribute names! (PhonyRails)' if attributes.size > 1
         end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -315,6 +315,21 @@ describe PhonyRails do
           dummy_klass.phony_normalize(:non_existing_attribute)
         }.should_not raise_error
       end
+
+      it "should accept supported options" do 
+        options = [:country_number, :default_country_number, :country_code, :default_country_code, :add_plus, :as]
+        options.each do |option_sym|
+          lambda {
+            dummy_klass.phony_normalize(:phone_number, option_sym => false)
+          }.should_not raise_error
+        end
+      end
+
+      it "should not accept unsupported options" do 
+        lambda {
+          dummy_klass.phony_normalize(:phone_number, unsupported_option: false)
+        }.should raise_error(ArgumentError)
+      end
     end
 
     describe 'using model#phony_normalized_method' do


### PR DESCRIPTION
@joost 

Fixes a bug where `phony_normalize` does not accept all the valid options ([listed here](https://github.com/joost/phony_rails/blob/3b4d120b1735d49a6a7f8f1cef9569840bb0eb1f/lib/phony_rails.rb#L14)). I discovered this when I was unable to do
```ruby
phony_normalize :phone_number, :add_plus => false
```