### PR TITLE
Adding default error translation for the Hebrew language

### DIFF
--- a/lib/phony_rails/locales/he.yml
+++ b/lib/phony_rails/locales/he.yml
@@ -1,0 +1,4 @@
+he:
+  errors:
+    messages:
+      improbable_phone: "אינו תקין"


### PR DESCRIPTION
Hi @joost , 

Awesome gem :+1: 
I just went ahead and added a translation for my native speaking language - Hebrew.

Thanks!
Paz.