### PR TITLE
Replace Data with Setup.data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /.idea/
 .ruby-gemset
 .ruby-version
+coverage/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     phony_rails (0.12.8)
       activesupport (>= 3.0)
-      countries (~> 0.8, >= 0.8.2)
+      countries (~> 0.11, >= 0.11.5)
       phony (~> 2.12)
 
 GEM
@@ -29,10 +29,10 @@ GEM
       timers (~> 4.0.0)
     coderay (1.1.0)
     connection_pool (2.2.0)
-    countries (0.11.4)
+    countries (0.11.5)
       currencies (~> 0.4.2)
       i18n_data (~> 0.7.0)
-    coveralls (0.8.1)
+    coveralls (0.8.2)
       json (~> 1.8)
       rest-client (>= 1.6.8, < 2)
       simplecov (~> 0.10.0)
@@ -127,7 +127,7 @@ GEM
     simplecov-html (0.10.0)
     slop (3.6.0)
     sqlite3 (1.3.10)
-    term-ansicolor (1.3.1)
+    term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -155,3 +155,6 @@ DEPENDENCIES
   rake
   rspec
   sqlite3
+
+BUNDLED WITH
+   1.10.5

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -7,7 +7,7 @@ require 'phony_rails/version'
 module PhonyRails
 
   def self.country_number_for(country_code)
-    ISO3166::Country::Data[country_code.to_s.upcase].try(:[], 'country_code')
+    ISO3166::Country::Setup.data[country_code.to_s.upcase].try(:[], 'country_code')
   end
 
   # This method requires a country_code attribute (eg. NL) and phone_number to be set.
@@ -59,7 +59,7 @@ module PhonyRails
   def self.plausible_number?(number, options = {})
     return false if number.nil? || number.blank?
     number = normalize_number(number, options)
-    country_number = options[:country_number] || country_number_for(options[:country_code]) || 
+    country_number = options[:country_number] || country_number_for(options[:country_code]) ||
       default_country_number = options[:default_country_number] || country_number_for(options[:default_country_code])
     Phony.plausible? number, cc: country_number
   rescue

--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.post_install_message = "It now ads a '+' to the normalized number when it starts with a country number!"
 
   gem.add_dependency "phony", '~> 2.12'
-  gem.add_dependency "countries", '~> 0.8', '>= 0.8.2'
+  gem.add_dependency "countries", '~> 0.11', '>= 0.11.5'
   gem.add_dependency "activesupport", ">= 3.0"
   gem.add_development_dependency "activerecord", ">= 3.0"
   gem.add_development_dependency "mongoid", ">= 3.0"


### PR DESCRIPTION
The `countries` gem has updated the `ISO3166::Country class` in version
0.11.5 so that you need to call `Setup.data` instead of `Data`.

In order to be able to run this gem locally, I had to upgrade coveralls
because term-ansicolor 1.3.1 no longer exists.

I also updated the `countries` gem dependency in this gemspec since this
new code will only work with 0.11.5 and above.

Closes #103.