### PR TITLE
Don't re-parse country codes YAML file every time it's needed.

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -13,7 +13,7 @@ module PhonyRails
   end
 
   def self.country_codes_hash
-    YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'data/country_codes.yaml'))
+    @country_codes_hash ||= YAML.load_file(File.join(File.dirname(File.expand_path(__FILE__)), 'data/country_codes.yaml'))
   end
 
   # This method requires a country_code attribute (eg. NL) and phone_number to be set.


### PR DESCRIPTION
#109 added a country codes YAML file in order to remove the dependency on the `countries` gem. This is all well and good, but the current implementation reloads and re-parses that file every time the hash is needed. This potentially triggers reloading/parsing every time a phone number is normalized which adds a huge amount of unnecessary disk and CPU overhead to normalization.

This patches adds a simple cache for that hash.