### PR TITLE
Fix #126 — Unexpected result when calling normalize_number multiple times

### DIFF
--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -234,12 +234,17 @@ describe PhonyRails do
 
       it "should force add country_code" do
         expect(PhonyRails.normalize_number('+4790909090', country_code: 'SE')).to eql('+464790909090')
-        expect(PhonyRails.normalize_number('004790909090', country_code: 'SE')).to eql('+4604790909090') # FIXME: differs due to Phony.normalize in v2.7.1?!
+        expect(PhonyRails.normalize_number('+47909090', country_code: 'SE')).to eql('+4647909090')
+        expect(PhonyRails.normalize_number('004790909090', country_code: 'SE')).to eql('+464790909090')
         expect(PhonyRails.normalize_number('4790909090', country_code: 'SE')).to eql('+464790909090')
       end
 
+      it "should keep existing prefix" do
+        expect(PhonyRails.normalize_number('+4647909090', country_code: 'SE')).to eql('+4647909090')
+      end
+
       it "should recognize lowercase country codes" do
-        expect(PhonyRails.normalize_number('4790909090', country_code: 'se')).to eql('+464790909090')
+        expect(PhonyRails.normalize_number('47909090', country_code: 'se')).to eql('+4647909090')
       end
 
     end


### PR DESCRIPTION
This changes ```normalize_number``` default behavior using ```country_code``` option.
Prefix won't be added multiple times any more.

When there is an existing prefix that is not the expected one (ie right country number), the right prefix will be inserted.

```ruby
PhonyRails.normalize_number('+4790909090',     country_code: 'SE') # +464790909090
PhonyRails.normalize_number('+47909090',         country_code: 'SE') # +4647909090
PhonyRails.normalize_number('004790909090',   country_code: 'SE') # +464790909090
PhonyRails.normalize_number('4790909090',       country_code: 'SE') # +464790909090
PhonyRails.normalize_number('+336123456789', country_code: 'FR') # +336123456789
```

This fixes #126 