### PR TITLE
Adding Kosovo phone code

### DIFF
--- a/lib/data/country_codes.yaml
+++ b/lib/data/country_codes.yaml
@@ -489,6 +489,8 @@ WF:
   country_code: '681'
 WS:
   country_code: '685'
+XK:
+  country_code: '383'
 YE:
   country_code: '967'
 YT:


### PR DESCRIPTION
Calling code from: https://en.wikipedia.org/wiki/Telephone_numbers_in_Kosovo
Country ISO 3166 code from: https://en.wikipedia.org/wiki/Kosovo