### PR TITLE
only assigned normalize values if there is one

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -94,7 +94,8 @@ module PhonyRails
         attributes.each do |attribute|
           attribute_name = options[:as] || attribute
           fail(RuntimeError, "No attribute #{attribute_name} found on #{self.class.name} (PhonyRails)") unless self.class.attribute_method?(attribute_name)
-          send("#{attribute_name}=", PhonyRails.normalize_number(send(attribute), options))
+          new_value= PhonyRails.normalize_number(send(attribute), options)
+          send("#{attribute_name}=", new_value) if new_value
         end
       end
     end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -174,6 +174,26 @@ describe PhonyRails do
           phone = PhonyRails.normalize_number(phone, default_country_code: 'FR')
           expect(phone).to eq('+336123456789')
         end
+
+        it 'should pass Github issue #92 (invalid number with normalization)' do
+          ActiveRecord::Schema.define do
+            create_table :normal_homes do |table|
+              table.column :phone_number, :string
+            end
+          end
+
+          class NormalHome < ActiveRecord::Base
+            attr_accessor :phone_number
+            phony_normalize :phone_number, default_country_code: 'US'
+            validates :phone_number, phony_plausible: true
+          end
+
+          normal = NormalHome.new
+          normal.phone_number = 'HAHA'
+          expect(normal).to_not be_valid
+          expect(normal.phone_number).to eq('HAHA')
+          expect(normal.errors.messages).to include(phone_number: ["is an invalid number"])
+        end
       end
 
       it 'should not change original String' do

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -130,6 +130,7 @@ FORMATTED_AUSTRALIAN_NUMBER_WITH_COUNTRY_CODE = '+61 390133997'
 FRENCH_NUMBER_WITH_COUNTRY_CODE = '33627899541'
 FORMATTED_FRENCH_NUMBER_WITH_COUNTRY_CODE = '+33 627899541'
 INVALID_NUMBER = '123456789 123456789 123456789 123456789'
+NOT_A_NUMBER = 'HAHA'
 JAPAN_COUNTRY = 'jp'
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -153,6 +154,12 @@ describe PhonyPlausibleValidator do
 
     it "should invalidate an invalid number" do
       @home.phone_number = INVALID_NUMBER
+      expect(@home).to_not be_valid
+      expect(@home.errors.messages).to include(phone_number: ["is an invalid number"])
+    end
+
+    it "should invalidate not a number" do
+      @home.phone_number = NOT_A_NUMBER
       expect(@home).to_not be_valid
       expect(@home.errors.messages).to include(phone_number: ["is an invalid number"])
     end


### PR DESCRIPTION
@joost this fixes the issue https://github.com/joost/phony_rails/issues/92 for real, instead of having to work around it. 

The problem was we were assigning nils to the original value before we validate it, so even thought the behavior of the validator was correct, it can't actually generate an error. I have changed the behavior to only assigning the new value if there is one. 

So now the validation do not depend on the options `allow_nil` or `presence: true` 