### PR TITLE
Do not raise NoMethodError when an illegal country code is set

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -8,7 +8,7 @@ module PhonyRails
   def self.country_number_for(country_code)
     return if country_code.nil?
 
-    country_codes_hash[country_code.to_s.upcase]['country_code']
+    country_codes_hash.fetch(country_code.to_s.upcase, {})['country_code']
   end
 
   def self.country_codes_hash

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -50,6 +50,10 @@ ActiveRecord::Schema.define do
   create_table :mismatched_helpful_homes do |table|
     table.column :phone_number, :string
   end
+
+  create_table :invalid_country_code_helpful_homes do |table|
+    table.column :phone_number, :string
+  end
 end
 
 #--------------------
@@ -116,6 +120,17 @@ end
 class MismatchedHelpfulHome < ActiveRecord::Base
   attr_accessor :phone_number, :country_code
   validates :phone_number, phony_plausible: {ignore_record_country_code: true}
+end
+
+#--------------------
+
+class InvalidCountryCodeHelpfulHome < ActiveRecord::Base
+  attr_accessor :phone_number
+  validates_plausible_phone :phone_number
+
+  def country_code
+    "--"
+  end
 end
 #-----------------------------------------------------------------------------------------------------------------------
 # Tests
@@ -477,6 +492,29 @@ describe ActiveModel::Validations::HelperMethods do
 
       it "should allow this number" do
         expect(@home).to be_valid
+      end
+    end
+
+        #--------------------
+    context 'when a country code is set to something invalid' do
+      before(:each) do
+        @home = InvalidCountryCodeHelpfulHome.new
+      end
+
+      it "should allow any valid number" do
+        @home.phone_number = FRENCH_NUMBER_WITH_COUNTRY_CODE
+        expect(@home).to be_valid
+      end
+
+      it "should not allow any invalid number" do
+        @home.phone_number = INVALID_NUMBER
+        expect(@home).to_not be_valid
+      end
+
+      it "should not raise a NoMethodError when looking up a country fails (Regression)" do
+        expect {
+          @home.valid?
+        }.to_not raise_error
       end
     end
 


### PR DESCRIPTION
With the changes introduced in fdb432fca65648f18bb5bf1ed7240b69656e03aa the gem does not fail gracefully anymore when an illegal country code is set on the model.

I came across this error when I updated phony rails and ran the tests for a model that validates that the country code is a legal value (by setting it to something illegal). When I run this test, the phony validation fails with a `NoMethodError` because the phony gem cannot handle country codes anymore that are not in the list.

I hope the tests and change is ok. I am open to change stuff if somebody hints me into the right way :smile: 

~Klaus