### PR TITLE
Add support for phone numbers with extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,15 @@ You can also easily normalize a phone number String:
 "(0)30 1234 123".phony_normalized(country_code: 'NL') # => '301234123'
 ```
 
+Extensions are supported (identified by "ext", "ex", "x", "xt", "#", or ":") and will show at the end of the number:
+
+```ruby
+"+31 (0)30 1234 123 x999".phony_normalized # => '31301234123 x999'
+"+31 (0)30 1234 123 ext999".phony_normalized # => '31301234123 x999'
+"+31 (0)30 1234 123 #999".phony_normalized # => '31301234123 x999'
+```
+
+
 ### Find by normalized number
 
 Say you want to find a record by a phone number. Best is to normalize user input and compare to an attribute stored in the db.

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -90,11 +90,13 @@ module PhonyRails
 
   def self.extract_extension(number_and_ext)
     return [nil, nil] if number_and_ext.nil?
+    # :nocov:
     if subbed = number_and_ext.sub(COMMON_EXTENSIONS, '')
       [subbed, Regexp.last_match(2)]
     else
       [number_and_ext, nil]
     end
+    # :nocov:
   end
 
   def self.format_extension(number, ext)

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -28,6 +28,7 @@ module PhonyRails
     return if number.nil?
     original_number = number
     number = number.dup # Just to be sure, we don't want to change the original.
+    number, ext = extract_extension(number)
     number.gsub!(/[^\(\)\d\+]/, '') # Strips weird stuff from the number
     return if number.blank?
     if _country_number = options[:country_number] || country_number_for(options[:country_code])
@@ -39,25 +40,32 @@ module PhonyRails
       end
     elsif _default_country_number = options[:default_country_number] || country_number_for(options[:default_country_code])
       options[:add_plus] = true if options[:add_plus].nil?
-      # We try to add the default country number and see if it is a
-      # correct phone number. See https://github.com/joost/phony_rails/issues/87#issuecomment-89324426
-      unless number =~ /\A\+/ # if we don't have a +
-        if Phony.plausible?("#{_default_country_number}#{number}") || !Phony.plausible?(number) || country_code_from_number(number).nil?
-          number = "#{_default_country_number}#{number}"
-        elsif (number =~ /^0[^0]/) && Phony.plausible?("#{_default_country_number}#{number.gsub(/^0/, '')}")
-          # If the number starts with ONE zero (two might indicate a country code)
-          # and this is a plausible number for the default_country
-          # we prefer that one.
-          number = "#{_default_country_number}#{number.gsub(/^0/, '')}"
-        end
-      end
-      # number = "#{_default_country_number}#{number}" unless Phony.plausible?(number)
+      number = normalize_number_default_country(number, _default_country_number)
     end
     normalized_number = Phony.normalize(number)
     options[:add_plus] = true if options[:add_plus].nil? && Phony.plausible?(normalized_number)
-    options[:add_plus] ? "+#{normalized_number}" : normalized_number
+    normalized_number = options[:add_plus] ? "+#{normalized_number}" : normalized_number
+    format_extension(normalized_number, ext)
   rescue
     original_number # If all goes wrong .. we still return the original input.
+  end
+
+  def self.normalize_number_default_country(number, default_country_number)
+    # We try to add the default country number and see if it is a
+    # correct phone number. See https://github.com/joost/phony_rails/issues/87#issuecomment-89324426
+    unless number =~ /\A\+/ # if we don't have a +
+      if Phony.plausible?("#{default_country_number}#{number}") || !Phony.plausible?(number) || country_code_from_number(number).nil?
+        return "#{default_country_number}#{number}"
+      elsif (number =~ /^0[^0]/) && Phony.plausible?("#{default_country_number}#{number.gsub(/^0/, '')}")
+        # If the number starts with ONE zero (two might indicate a country code)
+        # and this is a plausible number for the default_country
+        # we prefer that one.
+        return "#{default_country_number}#{number.gsub(/^0/, '')}"
+      end
+    end
+    # number = "#{default_country_number}#{number}" unless Phony.plausible?(number)
+    # Just return the number unchanged
+    number
   end
 
   def self.country_code_from_number(number)
@@ -69,12 +77,28 @@ module PhonyRails
   # NB: This method calls #normalize_number and passes _options_ directly to that method.
   def self.plausible_number?(number, options = {})
     return false if number.nil? || number.blank?
+    number = extract_extension(number).first
     number = normalize_number(number, options)
     country_number = options[:country_number] || country_number_for(options[:country_code]) ||
                      options[:default_country_number] || country_number_for(options[:default_country_code])
     Phony.plausible? number, cc: country_number
   rescue
     false
+  end
+
+  COMMON_EXTENSIONS = /[ ]*(ext|ex|x|xt|#|:)+[^0-9]*\(*([-0-9]{1,})\)*#?$/i
+
+  def self.extract_extension(number_and_ext)
+    return [nil, nil] if number_and_ext.nil?
+    if subbed = number_and_ext.sub(COMMON_EXTENSIONS, '')
+      [subbed, Regexp.last_match(2)]
+    else
+      [number_and_ext, nil]
+    end
+  end
+
+  def self.format_extension(number, ext)
+    ext.present? ? "#{number} x#{ext}" : number
   end
 
   module Extension

--- a/lib/phony_rails/string_extensions.rb
+++ b/lib/phony_rails/string_extensions.rb
@@ -25,7 +25,7 @@ class String
     options = options.dup
     normalize_country_code = options.delete(:normalize)
     s, ext = PhonyRails.extract_extension(self)
-    s = (normalize_country_code ? PhonyRails.normalize_number(s, default_country_code: normalize_country_code.to_s, add_plus: false) : gsub(/\D/, ''))
+    s = (normalize_country_code ? PhonyRails.normalize_number(s, default_country_code: normalize_country_code.to_s, add_plus: false) : s.gsub(/\D/, ''))
     return if s.blank?
     return if options[:strict] && !Phony.plausible?(s)
     PhonyRails.format_extension(Phony.format(s, options.reverse_merge(format: :national)), ext)

--- a/lib/phony_rails/string_extensions.rb
+++ b/lib/phony_rails/string_extensions.rb
@@ -24,10 +24,11 @@ class String
     raise ArgumentError, "Expected options to be a Hash, got #{options.inspect}" unless options.is_a?(Hash)
     options = options.dup
     normalize_country_code = options.delete(:normalize)
-    s = (normalize_country_code ? PhonyRails.normalize_number(self, default_country_code: normalize_country_code.to_s, add_plus: false) : gsub(/\D/, ''))
+    s, ext = PhonyRails.extract_extension(self)
+    s = (normalize_country_code ? PhonyRails.normalize_number(s, default_country_code: normalize_country_code.to_s, add_plus: false) : gsub(/\D/, ''))
     return if s.blank?
     return if options[:strict] && !Phony.plausible?(s)
-    Phony.format(s, options.reverse_merge(format: :national))
+    PhonyRails.format_extension(Phony.format(s, options.reverse_merge(format: :national)), ext)
   rescue
     raise if options[:raise]
     s

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -91,6 +91,7 @@ describe PhonyRails do
             expect("101234123#{prefix}123".phony_formatted(normalize: :NL, format: :international)).to eql('+31 10 123 4123 x123')
             expect("31101234123#{prefix}123".phony_formatted(normalize: :NL)).to eql('010 123 4123 x123')
             expect("8887716095#{prefix}123".phony_formatted(format: :international, normalize: 'US', raise: true)).to eq('+1 (888) 771-6095 x123')
+            expect("+12145551212#{prefix}123".phony_formatted).to eq('(214) 555-1212 x123')
           end
         end
       end


### PR DESCRIPTION
Requested in issue #57 and #78, this pull request adds support for phone numbers with extensions.

Leveraging some code from the "phone" gem, I'm basically extracting the extension, running the normal code using Phony, then adding the extension back at the end.

```
"+31 (0)30 1234 123 x999".phony_normalized # => '31301234123 x999'
"+31 (0)30 1234 123 ext999".phony_normalized # => '31301234123 x999'
"+31 (0)30 1234 123 #999".phony_normalized # => '31301234123 x999'
```

I think there could be more options around formatting, but wanted to gauge interest in accepting the changes first.