### PR TITLE
Adds ability to pass symbols as option values to phony model helpers

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -103,7 +103,7 @@ module PhonyRails
       def assign_values_for_phony_symbol_options(options)
         symbol_options = [:country_number, :default_country_number, :country_code, :default_country_code]
         symbol_options.each do |option|
-          options[option] = self.send(options[option]) if options[option].is_a?(Symbol)
+          options[option] = send(options[option]) if options[option].is_a?(Symbol)
         end
       end
     end

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -87,6 +87,7 @@ module PhonyRails
       # It also adds the country_code (number), eg. 31 for NL numbers.
       def set_phony_normalized_numbers(attributes, options = {})
         options = options.dup
+        assign_values_for_phony_symbol_options(options)
         if respond_to?(:country_code)
           set_country_as = options[:enforce_record_country] ? :country_code : :default_country_code
           options[set_country_as] ||= country_code
@@ -96,6 +97,13 @@ module PhonyRails
           raise("No attribute #{attribute_name} found on #{self.class.name} (PhonyRails)") unless self.class.attribute_method?(attribute_name)
           new_value = PhonyRails.normalize_number(send(attribute), options)
           send("#{attribute_name}=", new_value) if new_value
+        end
+      end
+
+      def assign_values_for_phony_symbol_options(options)
+        symbol_options = [:country_number, :default_country_number, :country_code, :default_country_code]
+        symbol_options.each do |option|
+          options[option] = self.send(options[option]) if options[option].is_a?(Symbol)
         end
       end
     end
@@ -130,10 +138,11 @@ module PhonyRails
         attributes.each do |attribute|
           raise(StandardError, "Instance method normalized_#{attribute} already exists on #{name} (PhonyRails)") if method_defined?(:"normalized_#{attribute}")
           define_method :"normalized_#{attribute}" do |*args|
-            options = args.first || {}
+            options = main_options.merge(args.first || {})
+            assign_values_for_phony_symbol_options(options)
             raise(ArgumentError, "No attribute/method #{attribute} found on #{self.class.name} (PhonyRails)") unless respond_to?(attribute)
             options[:country_code] ||= country_code if respond_to?(:country_code)
-            PhonyRails.normalize_number(send(attribute), main_options.merge(options))
+            PhonyRails.normalize_number(send(attribute), options)
           end
         end
       end

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -8,7 +8,6 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
     return if value.blank?
 
     @record = record
-
     value = PhonyRails.normalize_number(value.dup, default_country_code: normalized_country_code) if normalized_country_code
     @record.errors.add(attribute, error_message) unless Phony.plausible?(value, cc: country_number)
   end
@@ -16,15 +15,15 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   private
 
   def error_message
-    options[:message] || :improbable_phone
+    options_value(:message) || :improbable_phone
   end
 
   def country_number
-    options[:country_number] || record_country_number || country_number_from_country_code
+    options_value(:country_number) || record_country_number || country_number_from_country_code
   end
 
   def record_country_number
-    @record.country_number if @record.respond_to?(:country_number) && !options[:ignore_record_country_number]
+    @record.country_number if @record.respond_to?(:country_number) && !options_value(:ignore_record_country_number)
   end
 
   def country_number_from_country_code
@@ -32,15 +31,23 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   end
 
   def country_code
-    options[:country_code] || record_country_code
+    options_value(:country_code) || record_country_code
   end
 
   def record_country_code
-    @record.country_code if @record.respond_to?(:country_code) && !options[:ignore_record_country_code]
+    @record.country_code if @record.respond_to?(:country_code) && !options_value(:ignore_record_country_code)
   end
 
   def normalized_country_code
-    options[:normalized_country_code]
+    options_value(:normalized_country_code)
+  end
+
+  def options_value(option)
+    if options[option].is_a?(Symbol)
+      @record.send(options[option])
+    else
+      options[option]
+    end
   end
 end
 

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -499,6 +499,11 @@ describe PhonyRails do
         model.country_code = nil
         expect(model.normalized_phone1_method(country_code: nil)).to eql('+49308612906')
       end
+
+      it 'should accept a symbol when setting country_code options' do
+        model = model_klass.new(symboled_phone_method: '02031234567', country_code_attribute: 'GB')
+        expect(model.normalized_symboled_phone_method).to eql('+442031234567')
+      end
     end
 
     describe 'using model#phony_normalize' do
@@ -536,6 +541,12 @@ describe PhonyRails do
         expect(lambda do
           dummy.valid?
         end).to raise_error(RuntimeError)
+      end
+
+      it 'should accept a symbol when setting country_code options' do
+        model = model_klass.new(symboled_phone: '0606060606', country_code_attribute: 'FR')
+        expect(model).to be_valid
+        expect(model.symboled_phone).to eql('+33606060606')
       end
     end
   end

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -526,20 +526,20 @@ describe ActiveModel::Validations::HelperMethods do
 
       it 'should validate a valid number with the right country code' do
         @home.phone_number = POLISH_NUMBER_WITH_COUNTRY_CODE
-        @home.phone_number_country_code = "PL"
+        @home.phone_number_country_code = 'PL'
         expect(@home).to be_valid
       end
 
       it 'should invalidate a valid number with the wrong country code' do
         @home.phone_number = FRENCH_NUMBER_WITH_COUNTRY_CODE
-        @home.phone_number_country_code = "PL"
+        @home.phone_number_country_code = 'PL'
         expect(@home).to_not be_valid
         expect(@home.errors.messages).to include(phone_number: ['is an invalid number'])
       end
 
       it 'should invalidate a valid number without a country code' do
         @home.phone_number = VALID_NUMBER
-        @home.phone_number_country_code = "PL"
+        @home.phone_number_country_code = 'PL'
         expect(@home).to_not be_valid
         expect(@home.errors.messages).to include(phone_number: ['is an invalid number'])
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,18 +21,22 @@ ActiveRecord::Schema.define do
     table.column :phone_number, :string
     table.column :phone_number_as_normalized, :string
     table.column :fax_number, :string
+    table.column :country_code_attribute, :string
+    table.column :symboled_phone, :string
   end
 end
 
 module SharedModelMethods
   extend ActiveSupport::Concern
   included do
-    attr_accessor :phone_method, :phone1_method, :country_code
+    attr_accessor :phone_method, :phone1_method, :symboled_phone_method, :country_code, :country_code_attribute
     phony_normalized_method :phone_attribute # adds normalized_phone_attribute method
     phony_normalized_method :phone_method # adds normalized_phone_method method
     phony_normalized_method :phone1_method, default_country_code: 'DE' # adds normalized_phone_method method
+    phony_normalized_method :symboled_phone_method, country_code: :country_code_attribute # adds phone_with_symboled_options method
     phony_normalize :phone_number # normalized on validation
     phony_normalize :fax_number, default_country_code: 'AU'
+    phony_normalize :symboled_phone, default_country_code: :country_code_attribute
   end
 end
 
@@ -57,6 +61,8 @@ class MongoidModel
   field :phone_number,    type: String
   field :phone_number_as_normalized, type: String
   field :fax_number
+  field :country_code_attribute, type: String
+  field :symboled_phone, type: String
   include SharedModelMethods
 end
 


### PR DESCRIPTION
Previously attributes such as country_code had to be strings and
could not be set at runtime. It was possible to set a method named
country_code on the model but it situations where you might have
multiple phone numbers on the same model this was still somewhat
limited.
Using symbols allows you to use other model attributes to set the
country code attributes.For instance the following is now possible

Table - Person
home_phone
mobile_phone
home_phone_country
mobile_phone_country

phony_normalize :home_phone, country_code: :home_phone_country
phony_normalize :mobile_phone, country_code: :mobile_phone_country