### PR TITLE
Read message value directly from options

### DIFF
--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -15,7 +15,7 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   private
 
   def error_message
-    options_value(:message) || :improbable_phone
+    options[:message] || :improbable_phone
   end
 
   def country_number
@@ -43,11 +43,11 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
   end
 
   def options_value(option)
-    if options[option].is_a?(Symbol)
-      @record.send(options[option])
-    else
-      options[option]
-    end
+    option_value = options[option]
+
+    return option_value unless option_value.is_a?(Symbol)
+
+    @record.send(option_value)
   end
 end
 


### PR DESCRIPTION
**Why**:
With the changes in PR #139, specifying a symbolized value for the
`message` option would cause that method to be called on the Model
object. If that method didn't exist, it resulted in a `NoMethodError`
exception. If that method did exist in the Model, and also as an i18n
key, then the Model method was used, as opposed to the i18n key.

The `message` option is meant to either be a String, or a symbol
corresponding to an i18n key. Therefore, it should be read directly
from `options[:message]` and not sent for further processing by the
`options_value` method.

**How**:
- Revert the `error_message` method back to its value prior to PR #139,
so that it uses `options[:message]`
- Add 3 new specs to cover these scenarios

Closes #140.