### PR TITLE
Fixed a bug that prevents a normalized attribute from being set to nil

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -144,7 +144,7 @@ module PhonyRails
           attribute_name = options[:as] || attribute
           raise("No attribute #{attribute_name} found on #{self.class.name} (PhonyRails)") unless self.class.attribute_method?(attribute_name)
           new_value = PhonyRails.normalize_number(send(attribute), options)
-          send("#{attribute_name}=", new_value) if new_value
+          send("#{attribute_name}=", new_value) if new_value || attribute_name != attribute
         end
       end
 

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -634,11 +634,26 @@ describe PhonyRails do
         expect(model.phone_number).to eql('+31101234123')
       end
 
+      it 'should nilify attribute when it is set to nil' do
+        model = model_klass.new(phone_number: '+31-(0)10-1234123')
+        model.phone_number = nil
+        expect(model).to be_valid
+        expect(model.phone_number).to eql(nil)
+      end
+
       it 'should set a normalized version of an attribute using :as option' do
         model_klass.phony_normalize :phone_number, as: :phone_number_as_normalized
         model = model_klass.new(phone_number: '+31-(0)10-1234123')
         expect(model).to be_valid
         expect(model.phone_number_as_normalized).to eql('+31101234123')
+      end
+
+      it 'should nilify normalized version of an attribute when it is set to nil using :as option ' do
+        model_klass.phony_normalize :phone_number, as: :phone_number_as_normalized
+        model = model_klass.new(phone_number: '+31-(0)10-1234123', phone_number_as_normalized: '+31101234123')
+        model.phone_number = nil
+        expect(model).to be_valid
+        expect(model.phone_number_as_normalized).to eq(nil)
       end
 
       it 'should not add a + using :add_plus option' do


### PR DESCRIPTION
#### The problem
When you specify a separate column to store the normalized version of a phone number attribute, setting the original attribute to nil does not set the normalized version to nil.

#### Repro example
```
class User < ActiveRecord::Base
  phony_normalize :phone_number, as: :normalized_phone_number
end

u = User.create(phone_number: '555-555-1234')
u.phone_number #=> '555-555-1234'
u.normalized_phone_number #=> '+15555551234'

u.update(phone_number: nil)
u.phone_number #=> nil
u.normalized_phone_number #=> '+15555551234' <-- this should be nil
```

#### The fix
I added a failing spec and then fixed the problem in the most obvious way that I could see, but it's pretty ugly. I'd be happy to improve it if you have any suggestions.