### PR TITLE
support for ActiveModel::Model alternative to database-backed models only

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ class SomeModel < ActiveRecord::Base
 end
 ```
 
+#### ActiveModel (models without database)
+
+For Rails-like models without a database, add:
+
+```ruby
+class SomeModel
+  include ActiveModel::Model # we get AR-like attributes and validations
+  include ActiveModel::Validations::Callbacks # a dependency for normalization
+
+  # your attributes must be defined, they are not inherited from a DB table
+  attr_accessor :phone_number, :phone_number_as_normalized
+
+  # Once the model is set up, we have the same things as with ActiveRecord
+  phony_normalize :phone_number, default_country_code: 'US'
+end
+```
+
 #### Mongoid
 
 For **Mongoid**, in keeping with Mongoid plug-in conventions you must include the `Mongoid::Phony` module:

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -201,6 +201,8 @@ end
 # check whether it is ActiveRecord or Mongoid being used
 ActiveRecord::Base.send :include, PhonyRails::Extension if defined?(ActiveRecord)
 
+ActiveModel::Model.send :include, PhonyRails::Extension if defined?(ActiveModel)
+
 if defined?(Mongoid)
   module Mongoid::Phony
     extend ActiveSupport::Concern

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -687,6 +687,12 @@ describe PhonyRails do
     end
   end
 
+  describe 'ActiveModel + ActiveModel::Validations::Callbacks' do
+    let(:model_klass) { ActiveModelModel }
+    let(:dummy_klass) { ActiveModelDummy }
+    it_behaves_like 'model with PhonyRails'
+  end
+
   describe 'ActiveRecord' do
     let(:model_klass) { ActiveRecordModel }
     let(:dummy_klass) { ActiveRecordDummy }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,18 @@ end
 class ActiveRecordDummy < ActiveRecordModel
 end
 
+class ActiveModelModel # in case you don't want a database for your model
+  include ActiveModel::Model # this provides most of the interface of AR
+  include ActiveModel::Validations::Callbacks # we use callbacks for normalization
+  include SharedModelMethods
+
+  # database columns don't give us free attributes, we have to define them
+  attr_accessor :phone_number, :phone_attribute, :phone_number_as_normalized, :country_code_attribute, :fax_number, :symboled_phone
+end
+
+class ActiveModelDummy < ActiveModelModel
+end
+
 class MongoidModel
   include Mongoid::Document
   include Mongoid::Phony


### PR DESCRIPTION
related to #143 

PhonyRails can be added to ActiveModel::Model as well as ActiveRecord::Base to enable usage in models that are not db-backed. There is also a dependency on ActiveModel::Validations::Callbacks as the normalization currently depends on a before_validate callback.

I am using this version for my project and have extended the basic test coverage to  #account for this usage variant. Please provide any relevant critique or feedback.