### PR TITLE
Do not use insecure multiline regex in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ so we can use:
 
 ```ruby
 validates_plausible_phone :phone_number, presence: true
-validates_plausible_phone :phone_number, with: /^\+\d+/
-validates_plausible_phone :phone_number, without: /^\+\d+/
-validates_plausible_phone :phone_number, presence: true, with: /^\+\d+/
+validates_plausible_phone :phone_number, with: /\A\+\d+/
+validates_plausible_phone :phone_number, without: /\A\+\d+/
+validates_plausible_phone :phone_number, presence: true, with: /\A\+\d+/
 ```
 
 the i18n key is `:improbable_phone`. Languages supported by default: de, en, fr, it, ja, kh, nl, tr, ua and ru.


### PR DESCRIPTION
ActiveModel >= 4.0 will raise a security related exception with the old example unless `multiline: true` is set as well. This doesn't make much sense for these use cases.

More info: http://guides.rubyonrails.org/security.html#regular-expressions
Relevant commit: https://github.com/rails/rails/commit/bc7c0b5c108ef47b24bb91c502429935bb34d214