### PR TITLE
Update phony_rails.gemspec

### DIFF
--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.post_install_message = 'PhonyRails v0.10.0 changes the way numbers are stored!'
   gem.post_install_message = "It now adds a '+' to the normalized number when it starts with a country number!"
 
-  gem.add_dependency 'phony', '~> 2.12'
+  gem.add_dependency 'phony', '~> 2.15.32'
   gem.add_dependency 'activesupport', '>= 3.0'
   gem.add_development_dependency 'activerecord', '>= 3.0'
   gem.add_development_dependency 'mongoid', '>= 3.0'


### PR DESCRIPTION
Updated phony version because Cameroon numbers were not properly validated (current number length should be 9).