### PR TITLE
Fix Rails 3 compatibility in issue #147

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -199,7 +199,7 @@ end
 # check whether it is ActiveRecord or Mongoid being used
 ActiveRecord::Base.send :include, PhonyRails::Extension if defined?(ActiveRecord)
 
-ActiveModel::Model.send :include, PhonyRails::Extension if defined?(ActiveModel)
+ActiveModel::Model.send :include, PhonyRails::Extension if defined?(ActiveModel::Model)
 
 if defined?(Mongoid)
   module Mongoid::Phony


### PR DESCRIPTION
Fixed it by if ActiveModel::Model is defined. ActiveModel is in Rails 3, but ActiveModel::Model is only there in Rails 4. Tests are passing.