### PR TITLE
Fixed belongs_to_required_by_default in Rails 5

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -192,7 +192,11 @@ module PhonyRails
 end
 
 # check whether it is ActiveRecord or Mongoid being used
-ActiveRecord::Base.send :include, PhonyRails::Extension if defined?(ActiveRecord)
+if defined?(ActiveRecord)
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::Base.send :include, PhonyRails::Extension
+  end
+end
 
 ActiveModel::Model.send :include, PhonyRails::Extension if defined?(ActiveModel::Model)
 


### PR DESCRIPTION
Similar to what was done for Cancancan [here](https://github.com/CanCanCommunity/cancancan/issues/342#issuecomment-239687074) or Devise [here](https://github.com/plataformatec/devise/commit/c2c74b0).