### PR TITLE
Conditional Normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ class SomeModel < ActiveRecord::Base
 
   # Creates method normalized_fax_number that returns the normalized version of fax_number
   phony_normalized_method :fax_number
+
+  # Conditionally normalizes the attribute
+  phony_normalize :recipient, default_country_code: 'US', if: -> { contact_method == 'phone_number' }
 end
 ```
 

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -164,7 +164,7 @@ module PhonyRails
 
         options[:enforce_record_country] = true if options[:enforce_record_country].nil?
 
-        conditional = create_before_validation_conditional_hash options
+        conditional = create_before_validation_conditional_hash(options)
 
         # Add before validation that saves a normalized version of the phone number
         before_validation conditional do
@@ -196,7 +196,7 @@ module PhonyRails
       # This allows conditional normalization
       # Returns something like `{ unless: -> { attribute == 'something' } }`
       # If no if/unless options passed in, returns `{ if: -> { true } }`
-      def create_before_validation_conditional_hash options
+      def create_before_validation_conditional_hash(options)
         if options[:if].present?
           type = :if
           source = options[:if]
@@ -212,7 +212,7 @@ module PhonyRails
         conditional[type] = if source.respond_to?(:call)
                               source
                             elsif source.respond_to?(:to_sym)
-                              -> { self.send(source.to_sym) }
+                              -> { send(source.to_sym) }
                             else
                               -> { source }
                             end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -741,7 +741,7 @@ describe PhonyRails do
           end
 
           it 'should only normalize if the :unless conditional is false' do
-            model_klass.phony_normalize :recipient, default_country_code: 'US', unless: -> { delivery_method == 'email'}
+            model_klass.phony_normalize :recipient, default_country_code: 'US', unless: -> { delivery_method == 'email' }
 
             sms_alarm = model_klass.new recipient: '222 333 4444', delivery_method: 'sms'
             email_alarm = model_klass.new recipient: 'foo123@example.com', delivery_method: 'email'

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -729,7 +729,27 @@ describe PhonyRails do
         end
 
         context 'using lambdas' do
+          it 'should only normalize if the :if conditional is true' do
+            model_klass.phony_normalize :recipient, default_country_code: 'US', if: -> { delivery_method == 'sms' }
 
+            sms_alarm = model_klass.new recipient: '222 333 4444', delivery_method: 'sms'
+            email_alarm = model_klass.new recipient: 'foo123@example.com', delivery_method: 'email'
+            expect(sms_alarm).to be_valid
+            expect(email_alarm).to be_valid
+            expect(sms_alarm.recipient).to eq('+12223334444')
+            expect(email_alarm.recipient).to eq('foo123@example.com')
+          end
+
+          it 'should only normalize if the :unless conditional is false' do
+            model_klass.phony_normalize :recipient, default_country_code: 'US', unless: -> { delivery_method == 'email'}
+
+            sms_alarm = model_klass.new recipient: '222 333 4444', delivery_method: 'sms'
+            email_alarm = model_klass.new recipient: 'foo123@example.com', delivery_method: 'email'
+            expect(sms_alarm).to be_valid
+            expect(email_alarm).to be_valid
+            expect(sms_alarm.recipient).to eq('+12223334444')
+            expect(email_alarm.recipient).to eq('foo123@example.com')
+          end
         end
       end
     end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -702,6 +702,36 @@ describe PhonyRails do
         expect(model).to be_valid
         expect(model.symboled_phone).to eql('+33606060606')
       end
+
+      context 'conditional normalization' do
+        context 'standalone methods' do
+          it 'should only normalize if the :if conditional is true' do
+            model_klass.phony_normalize :recipient, default_country_code: 'US', if: :use_phone?
+
+            sms_alarm = model_klass.new recipient: '222 333 4444', delivery_method: 'sms'
+            email_alarm = model_klass.new recipient: 'foo123@example.com', delivery_method: 'email'
+            expect(sms_alarm).to be_valid
+            expect(email_alarm).to be_valid
+            expect(sms_alarm.recipient).to eq('+12223334444')
+            expect(email_alarm.recipient).to eq('foo123@example.com')
+          end
+
+          it 'should only normalize if the :unless conditional is false' do
+            model_klass.phony_normalize :recipient, default_country_code: 'US', unless: :use_email?
+
+            sms_alarm = model_klass.new recipient: '222 333 4444', delivery_method: 'sms'
+            email_alarm = model_klass.new recipient: 'foo123@example.com', delivery_method: 'email'
+            expect(sms_alarm).to be_valid
+            expect(email_alarm).to be_valid
+            expect(sms_alarm.recipient).to eq('+12223334444')
+            expect(email_alarm.recipient).to eq('foo123@example.com')
+          end
+        end
+
+        context 'using lambdas' do
+
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,7 @@ end
 module SharedModelMethods
   extend ActiveSupport::Concern
   included do
-    attr_accessor :phone_method, :phone1_method, :symboled_phone_method, :country_code, :country_code_attribute
+    attr_accessor :phone_method, :phone1_method, :symboled_phone_method, :country_code, :country_code_attribute, :recipient, :delivery_method
     phony_normalized_method :phone_attribute # adds normalized_phone_attribute method
     phony_normalized_method :phone_method # adds normalized_phone_method method
     phony_normalized_method :phone1_method, default_country_code: 'DE' # adds normalized_phone_method method
@@ -38,6 +38,14 @@ module SharedModelMethods
     phony_normalize :phone_number # normalized on validation
     phony_normalize :fax_number, default_country_code: 'AU'
     phony_normalize :symboled_phone, default_country_code: :country_code_attribute
+
+    def use_phone?
+      delivery_method == 'sms'
+    end
+
+    def use_email?
+      delivery_method == 'email'
+    end
   end
 end
 


### PR DESCRIPTION
Allows an `:if` or `:unless` option to be passed to `phony_normalize`. Works with symbols that reference methods or lambdas, just like validations do.

More comprehensively fixes https://github.com/joost/phony_rails/issues/149

I had the use case for an alarm that has a recipient, which can be an email or a phone number (sms), so I wanted to be able to conditionally normalize the recipient field - otherwise it would butcher an email address with numbers in it (see tests).

```ruby
phony_normalize :recipient, default_country_code: 'US', if: -> { delivery_method == 'sms' }
phony_normalize :recipient, default_country_code: 'US', if: :sms_alarm?
```
The code is maybe a little more complex than I would like, but the alternative was to be very verbose because there is some nested conditional stuff (if with proc, unless with proc, if with symbol, unless with symbol).

Thanks!