### PR TITLE
Fix code example in README to match description

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can validate against the normalized input as opposed to the raw input:
 
 ```ruby
 phony_normalize :phone_number, as: :phone_number_normalized, default_country_code: 'US'
-validates_plausible_phone :phone_number_normalized, normalized_country_code: 'US'
+validates_plausible_phone :phone_number_normalized
 ```
 
 Validation supports phone numbers with extension, such as `+18181231234 x1234` or `'+1 (818)151-5483 #4312'` out-of-the-box.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can validate against the normalized input as opposed to the raw input:
 
 ```ruby
 phony_normalize :phone_number, as: :phone_number_normalized, default_country_code: 'US'
-validates_plausible_phone :phone_number_normalized
+validates_plausible_phone :phone_number_normalized, presence: true, if: :phone_number?
 ```
 
 Validation supports phone numbers with extension, such as `+18181231234 x1234` or `'+1 (818)151-5483 #4312'` out-of-the-box.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You can validate against the normalized input as opposed to the raw input:
 
 ```ruby
 phony_normalize :phone_number, as: :phone_number_normalized, default_country_code: 'US'
-validates_plausible_phone :phone_number, normalized_country_code: 'US'
+validates_plausible_phone :phone_number_normalized, normalized_country_code: 'US'
 ```
 
 Validation supports phone numbers with extension, such as `+18181231234 x1234` or `'+1 (818)151-5483 #4312'` out-of-the-box.


### PR DESCRIPTION
The description for the code example says:

> You can validate against the normalized input as opposed to the raw input:

but the code example is still validating the raw input. This example "works" as long as the user enters a US number since the validation defaults to "US", but breaks if a an "IT" number is entered, for example.

Also, since we're validating the already normalized phone number, I don't think providing the "normalized_country_code" option is useful. 

EDIT:
I added commit e44e76e because I'm guessing in the most common use case people don't want their records to be valid if the user enters a random string like "whatever", but also don't want to force a phone number - if they do, they should validate that the "phone_number" is present.
