### PR TITLE
return country from phone number

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -93,6 +93,11 @@ module PhonyRails
     Phony.split(Phony.normalize(number)).first
   end
 
+  def self.country_from_number(number)
+    return nil unless Phony.plausible?(number)
+    country_codes_hash.select { |_country, hash| hash['country_code'] == country_code_from_number(number) }.keys[0]
+  end
+
   # Wrapper for Phony.plausible?.  Takes the same options as #normalize_number.
   # NB: This method calls #normalize_number and passes _options_ directly to that method.
   def self.plausible_number?(number, options = {})

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -483,6 +483,12 @@ describe PhonyRails do
     end
   end
 
+  describe 'PhonyRails.country_from_number' do
+    it 'returns the country of the plausible phone number' do
+      expect(PhonyRails.country_from_number('+32475000000')).to eq 'BE'
+    end
+  end
+
   describe 'PhonyRails#format_extension' do
     it 'returns just number if no extension' do
       expect(PhonyRails.format_extension('+123456789', nil)).to eq '+123456789'


### PR DESCRIPTION
Its confusing that `country_code_from_number` return a `country_number`

I would rather do 
`country_number_from_number` => "32"
`country_code_from_number` => "BE"

But I don't want to break existing stuff.