### PR TITLE
Fix default country code in brackets

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -72,7 +72,7 @@ module PhonyRails
   def self.normalize_number_default_country(number, default_country_number)
     # We try to add the default country number and see if it is a
     # correct phone number. See https://github.com/joost/phony_rails/issues/87#issuecomment-89324426
-    unless number =~ /\A\+/ # if we don't have a +
+    unless number =~ /\+/ # if we don't have a +
       return "#{default_country_number}#{number}" if Phony.plausible?("#{default_country_number}#{number}") || !Phony.plausible?(number) || country_code_from_number(number).nil?
       # If the number starts with ONE zero (two might indicate a country code)
       # and this is a plausible number for the default_country

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -215,7 +215,7 @@ describe PhonyRails do
 
         it 'should pass Github issue #170' do
           phone = '(+49) 175 123 4567'
-          phone = PhonyRails.normalize_number(phone)
+          phone = PhonyRails.normalize_number(phone, default_country_code: 'DE')
           expect(phone).to eq('+491751234567')
         end
       end


### PR DESCRIPTION
Hey @joost,

thanks for your work! As mentioned in #170, the error we found exists only when the default country code is set. I adjusted the test case and fixed the issue (all tests passed).

What do you think, is this a feasible solution? I also thought about removing brackets and then checking for a + in the beginning (`unless number.gsub(/[\(\)]/, '') =~ /\A\+/`), but it seems overdone to me.
