### PR TITLE
Extension option added to normalize_number

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -41,6 +41,7 @@ module PhonyRails
   #   :country_code => The country code we should use.
   #   :default_country_code => Some fallback code (eg. 'NL') that can be used as default (comes from phony_normalize_numbers method).
   #   :add_plus => Add a '+' in front so we know the country code is added. (default: true)
+  #   :extension => Includes the extension. (default: true)
   # This idea came from:
   #   http://www.redguava.com.au/2011/06/rails-convert-phone-numbers-to-international-format-for-sms/
   def self.normalize_number(number, options = {})

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -64,7 +64,10 @@ module PhonyRails
     normalized_number = Phony.normalize(number)
     options[:add_plus] = true if options[:add_plus].nil? && Phony.plausible?(normalized_number)
     normalized_number = options[:add_plus] ? "+#{normalized_number}" : normalized_number
-    format_extension(normalized_number, ext)
+
+    options[:extension] = true if options[:extension].nil?
+    normalized_number = options[:extension] ? format_extension(normalized_number, ext) : normalized_number
+    normalized_number
   rescue StandardError
     original_number # If all goes wrong .. we still return the original input.
   end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -344,13 +344,9 @@ describe PhonyRails do
         end
 
         it "should remove #{prefix} extension (with extension: false)" do
-          expect(PhonyRails.normalize_number("some nasty stuff in this +31 number 10-1234123 string #{prefix}123", extension: false, country_code: 'NL')).to eql('+31101234123')
-          expect(PhonyRails.normalize_number("070-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
           expect(PhonyRails.normalize_number("0031-70-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
           expect(PhonyRails.normalize_number("+31-70-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
           expect(PhonyRails.normalize_number("0322-69497#{prefix}123", extension: false, country_code: 'BE')).to eql('+3232269497')
-          expect(PhonyRails.normalize_number("+32 3 226 94 97#{prefix}123", extension: false, country_code: 'BE')).to eql('+3232269497')
-          expect(PhonyRails.normalize_number("0450 764 000#{prefix}123", extension: false, country_code: 'AU')).to eql('+61450764000')
         end
       end
     end

--- a/spec/lib/phony_rails_spec.rb
+++ b/spec/lib/phony_rails_spec.rb
@@ -342,6 +342,16 @@ describe PhonyRails do
           expect(PhonyRails.normalize_number("+32 3 226 94 97#{prefix}123", default_country_code: 'BE')).to eql('+3232269497 x123')
           expect(PhonyRails.normalize_number("0450 764 000#{prefix}123", default_country_code: 'AU')).to eql('+61450764000 x123')
         end
+
+        it "should remove #{prefix} extension (with extension: false)" do
+          expect(PhonyRails.normalize_number("some nasty stuff in this +31 number 10-1234123 string #{prefix}123", extension: false, country_code: 'NL')).to eql('+31101234123')
+          expect(PhonyRails.normalize_number("070-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
+          expect(PhonyRails.normalize_number("0031-70-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
+          expect(PhonyRails.normalize_number("+31-70-4157134#{prefix}123", extension: false, country_code: 'NL')).to eql('+31704157134')
+          expect(PhonyRails.normalize_number("0322-69497#{prefix}123", extension: false, country_code: 'BE')).to eql('+3232269497')
+          expect(PhonyRails.normalize_number("+32 3 226 94 97#{prefix}123", extension: false, country_code: 'BE')).to eql('+3232269497')
+          expect(PhonyRails.normalize_number("0450 764 000#{prefix}123", extension: false, country_code: 'AU')).to eql('+61450764000')
+        end
       end
     end
 


### PR DESCRIPTION
This adds support for `PhonyRails.normalize_number('555-123-1234 x44', extension: false) == '+15551231234'`

Your gem is a life saver but sometimes I have needed to normalize a number and drop the extension (for example using twilio) and now that's possible. Hopefully others find this change useful.