### PR TITLE
add lambda support for default country code

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,3 +61,6 @@ Style/Documentation:
     - 'lib/phony_rails.rb'
     - 'lib/phony_rails/string_extensions.rb'
     - 'lib/validators/phony_validator.rb'
+
+Style/RescueModifier:
+  Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: ruby
 rvm:
-- 2.2.5
-- 2.3.1
+- 2.3.7
+- 2.4.4
+- 2.5.1
 script:
 - bundle exec rspec spec
 - bundle exec rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phony_rails (0.14.7)
+    phony_rails (0.14.8)
       activesupport (>= 3.0)
       phony (> 2.15)
 
@@ -74,7 +74,7 @@ GEM
     parallel (1.12.0)
     parser (2.4.0.2)
       ast (~> 2.3)
-    phony (2.16.3)
+    phony (2.16.5)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -140,4 +140,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/lib/phony_rails/version.rb
+++ b/lib/phony_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PhonyRails
-  VERSION = '0.14.7'
+  VERSION = '0.14.8'
 end

--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require File.expand_path('../lib/phony_rails/version', __FILE__)
+require File.expand_path('lib/phony_rails/version', __dir__)
 
 Gem::Specification.new do |gem|
   gem.authors       = ['Joost Hietbrink']

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,10 @@ end
 module SharedModelMethods
   extend ActiveSupport::Concern
   included do
-    attr_accessor :phone_method, :phone1_method, :symboled_phone_method, :country_code, :country_code_attribute, :recipient, :delivery_method
+    attr_accessor(
+      :country_code, :country_code_attribute, :custom_country_code, :delivery_method,
+      :home_country, :phone_method, :phone1_method, :recipient, :symboled_phone_method
+    )
     phony_normalized_method :phone_attribute # adds normalized_phone_attribute method
     phony_normalized_method :phone_method # adds normalized_phone_method method
     phony_normalized_method :phone1_method, default_country_code: 'DE' # adds normalized_phone_method method


### PR DESCRIPTION
- connected to issue #174
- allow custom attribute from current model/ attribute from association
- run travis against latest patch of rubies and add 2.4 & 2.5 versions into yml file
- minor bump on phony gem