### PR TITLE
Add UK country_code.

### DIFF
--- a/lib/data/country_codes.yaml
+++ b/lib/data/country_codes.yaml
@@ -463,6 +463,8 @@ UA:
   country_code: '380'
 UG:
   country_code: '256'
+UK:
+  country_code: '44'
 UM:
   country_code: ''
 US:


### PR DESCRIPTION
The Wikipedia page says about both GB and UK, but only GB was present.