### PR TITLE
Add possibility to return original phone number when is not valid

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,22 @@ validates_plausible_phone :phone_number_normalized, presence: true, if: :phone_n
 
 Validation supports phone numbers with extension, such as `+18181231234 x1234` or `'+1 (818)151-5483 #4312'` out-of-the-box.
 
+Return original value after validation:
+
+The flag normalize_when_valid (disabled by default), allows to return the original phone_number when is the object is not valid. When phone validation fails, normalization is not triggered at all. It could prevent a situation where user fills in the phone number and after validation, he gets back different, already normalized phone number value, even if phone number was wrong.
+
+Example usage:
+
+```ruby
+validates_plausible_phone :phone_number
+phony_normalize :phone_number, country_code: :country_code, normalize_when_valid: true
+```
+
+Filling in the number will result with following:
+
+When the number is incorrect (e.g. phone_number: `+44 888 888 888` for country_code 'PL'), the original validation behavior is preserved, but if the number is still invalid, the original value is returned.
+When number is valid, it will save the normalized number (e.g. `+48 888 888 888` will be saved as `+48888888888`).
+
 #### Allowing records country codes to not match phone number country codes
 
 You may have a record specifying one country (via a `country_code` attribute) but using a phone number from another country.  For example, your record may be from Japan but have a phone number from the Philippines. By default, `phony_rails` will consider your record's `country_code` as part of the validation.  If that country doesn't match the country code in the phone number, validation will fail.

--- a/lib/validators/phony_validator.rb
+++ b/lib/validators/phony_validator.rb
@@ -4,6 +4,7 @@
 # Usage:
 #   validate :phone_number, :phony_plausible => true
 require 'active_model'
+
 class PhonyPlausibleValidator < ActiveModel::EachValidator
   # Validates a String using Phony.plausible? method.
   def validate_each(record, attribute, value)
@@ -13,6 +14,8 @@ class PhonyPlausibleValidator < ActiveModel::EachValidator
     value = PhonyRails.normalize_number(value.dup, default_country_code: normalized_country_code) if normalized_country_code
     value = PhonyRails.extract_extension(value).first
     @record.errors.add(attribute, error_message) unless Phony.plausible?(value, cc: country_number)
+    @record.public_send("#{attribute}=", @record.public_send("#{attribute}_original")) if @record.respond_to?("#{attribute}_original") &&
+                                                                                          !Phony.plausible?(value, cc: country_number)
   end
 
   private


### PR DESCRIPTION
The purpose of this PR is to add ability to return original phone number while using both `validates_plausible_phone` and `phony_normalize`.

Original behavior:
When both `validates_plausible_phone` and `phony_normalize` are defined in the model, validation runs first, and then the number is normalized. However, when the number is invalid, the altered number is returned, so users might be confused that the form shows something different than they typed.

New behavior:
I added a new flag `normalize_when_valid` (disabled by default), which allows to return the original phone_number when is the object is not valid. When phone validation fails, normalization is not triggered at all.

Example usage:

```
class NormalizabledPhoneHome < ActiveRecord::Base
  validates_plausible_phone :phone_number
  phony_normalize :phone_number, country_code: :country_code, normalize_when_valid: true
end
```

Filling in the number will result with following:

1. When the number is incorrect (e.g. `phone_number: '+44 888 888 888'` for country_code 'PL'), the original validation behavior is preserved, but if the number is still invalid, the original value is returned.
2. When number is valid, it will save the normalized number (e.g. `+48 888 888 888` will be saved as`+48888888888`).