### PR TITLE
Fixing #195 - Original value should be cached in correct instance var

### DIFF
--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -176,8 +176,9 @@ module PhonyRails
     end
 
     def cache_original_attribute(current_instance, attribute)
-      current_instance.define_singleton_method("#{attribute}_original=")  { |value| @original = value }
-      current_instance.define_singleton_method("#{attribute}_original") { @original }
+      attribute_name = "#{attribute}_original"
+      current_instance.define_singleton_method("#{attribute_name}=")  { |value| instance_variable_set("@#{attribute_name}", value) }
+      current_instance.define_singleton_method(attribute_name) { instance_variable_get("@#{attribute_name}") }
       current_instance.public_send("#{attribute}_original=", current_instance.public_send(attribute.to_s))
     end
 

--- a/lib/phony_rails.rb
+++ b/lib/phony_rails.rb
@@ -177,7 +177,7 @@ module PhonyRails
 
     def cache_original_attribute(current_instance, attribute)
       attribute_name = "#{attribute}_original"
-      current_instance.define_singleton_method("#{attribute_name}=")  { |value| instance_variable_set("@#{attribute_name}", value) }
+      current_instance.define_singleton_method("#{attribute_name}=") { |value| instance_variable_set("@#{attribute_name}", value) }
       current_instance.define_singleton_method(attribute_name) { instance_variable_get("@#{attribute_name}") }
       current_instance.public_send("#{attribute}_original=", current_instance.public_send(attribute.to_s))
     end

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -172,9 +172,11 @@ class MessageOptionSameAsModelMethod < HelpfulHome
 end
 #--------------------
 class NormalizabledPhoneHome < ActiveRecord::Base
-  attr_accessor :phone_number, :country_code
+  attr_accessor :phone_number, :phone_number2, :country_code
   validates_plausible_phone :phone_number
+  validates_plausible_phone :phone_number2
   phony_normalize :phone_number, country_code: 'PL', normalize_when_valid: true
+  phony_normalize :phone_number2, country_code: 'PL', normalize_when_valid: true
 end
 
 #-----------------------------------------------------------------------------------------------------------------------
@@ -666,6 +668,23 @@ describe ActiveModel::Validations::HelperMethods do
 
         expect(@home).to be_valid
         expect(@home.phone_number).to eql('+48799449595')
+      end
+
+      it 'does not normalize code after validation with multiple attributes' do
+        @home = NormalizabledPhoneHome.new
+        @home.phone_number = '+44 799 449 595'
+        @home.phone_number2 = '+44 222 111 333'
+        @home.country_code = 'PL'
+
+        expect(@home).to_not be_valid
+        expect(@home.phone_number).to eql('+44 799 449 595')
+        expect(@home.phone_number2).to eql('+44 222 111 333')
+
+        @home.phone_number = '+48 799 449 595'
+        @home.phone_number2 = '+48 222 111 333'
+        expect(@home).to be_valid
+        expect(@home.phone_number).to eql('+48799449595')
+        expect(@home.phone_number2).to eql('+48222111333')
       end
     end
   end


### PR DESCRIPTION
Previously was cached in `@original` and would collide if more than 1
definition existed for a class.