### PR TITLE
Updated phony gem requirements to be Ruby 3 compatible

### DIFF
--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.post_install_message = "PhonyRails v0.10.0 changes the way numbers are stored!\nIt now adds a ' + ' to the normalized number when it starts with a country number!"
 
   gem.add_runtime_dependency 'activesupport', '>= 3.0'
-  gem.add_runtime_dependency 'phony', '> 2.15'
+  gem.add_runtime_dependency 'phony', '>= 2.18.12'
   gem.add_development_dependency 'activerecord', '>= 3.0'
   gem.add_development_dependency 'mongoid', '>= 3.0'
 


### PR DESCRIPTION
The version of Phony is incompatible with Ruby3, due to its use of creating Procs without a block.

The gem version updates have mostly been updates to the database and configuration of various countries phone data.

2.18.12 is where they fixed the Ruby 3 compatibility: https://github.com/floere/phony/blob/master/history.textile#version-21812