### PR TITLE
Remove old gem post-install message

### DIFF
--- a/phony_rails.gemspec
+++ b/phony_rails.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |gem|
   gem.version       = PhonyRails::VERSION
   gem.required_ruby_version = '>= 2.4'
 
-  gem.post_install_message = "PhonyRails v0.10.0 changes the way numbers are stored!\nIt now adds a ' + ' to the normalized number when it starts with a country number!"
-
   gem.add_runtime_dependency 'activesupport', '>= 3.0'
   gem.add_runtime_dependency 'phony', '>= 2.18.12'
   gem.add_development_dependency 'activerecord', '>= 3.0'


### PR DESCRIPTION
The post-install warning message introduced with PhonyRails v0.10.0 (which was released in 2015) is no longer relevant, as the behavior described has been in place for over 8 years.

This change removes the post-install message.