### PR TITLE
Add Portuguese translation for validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ validates_plausible_phone :phone_number, without: /\A\+\d+/
 validates_plausible_phone :phone_number, presence: true, with: /\A\+\d+/
 ```
 
-the i18n key is `:improbable_phone`. Languages supported by default: de, en, es, fr, it, ja, kh, ko, nl, tr, ua and ru.
+the i18n key is `:improbable_phone`. Languages supported by default: de, en, es, fr, it, ja, kh, ko, nl, pt, tr, ua and ru.
 
 You can also validate if a number has the correct country number:
 

--- a/lib/phony_rails/locales/pt.yml
+++ b/lib/phony_rails/locales/pt.yml
@@ -1,0 +1,4 @@
+es:
+  errors:
+    messages:
+      improbable_phone: "é um número inválido"

--- a/spec/lib/validators/phony_validator_spec.rb
+++ b/spec/lib/validators/phony_validator_spec.rb
@@ -327,6 +327,14 @@ describe PhonyPlausibleValidator do
         expect(@home.errors.messages.to_hash).to include(phone_number: ['является недействительным номером'])
       end
     end
+    
+    it 'should translate the error message in Portuguese' do
+      I18n.with_locale(:pt) do
+        @home.phone_number = INVALID_NUMBER
+        @home.valid?
+        expect(@home.errors.messages.to_hash).to include(phone_number: ['é um número inválido'])
+      end
+    end
   end
 end
 


### PR DESCRIPTION
I am using phony_rails and I have created custom locale translation for the error message in Portuguese. 

Here I created the pull request to add here and help others that need the validation message in Portuguese.